### PR TITLE
Bug 1628679 - Ensure engines are sorted by id within order hint.

### DIFF
--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -58,6 +58,16 @@ async function loadEngines() {
     return telemetryId;
   }
 
+  // Approximate the default sort order (we can't do exact order as
+  // we don't have the display names)
+  const collator = new Intl.Collator();
+  engines.sort((a, b) => {
+    if (a.orderHint == b.orderHint) {
+      return collator.compare(a.webExtension.id, b.webExtension.id);
+    }
+    return b.orderHint - a.orderHint;
+  });
+
   const list = engines.map(
     (e, i) => `
     <div data-id="${e.webExtension.id}">${i + 1}</div>


### PR DESCRIPTION
This is not 100% accurate as we don't have the display name, however it will likely give easier/quicker matching for most locales.