### PR TITLE
Bug 1628760 - Add a comparison view to show the differences between two server configurations.

### DIFF
--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -10,70 +10,113 @@
 
 <body class="loading">
   <form>
-  <fieldset id="settings">
-    <legend>Configuration Settings</legend>
-    <div id="server-settings">
-      <table>
-        <tr>
-          <th>Server</th>
-          <th colspan="2">Configuration</th>
-        </tr>
-        <tr>
-          <td>Production:</td>
-          <td>
-            <span class="radio">
+    <section id="engines">
+      <div id="tabs">
+        <button id="by-locales">Engines by locale/region</button>
+        <button id="by-engine">Locale/region by Engine</button>
+        <button id="compare-configs">Compare Configurations</button>
+      </div>
+
+      <div id="server-settings">
+        <fieldset id="settings">
+          <legend>Primary Config</legend>
+          <div id="primary-settings" class="server-settings-table">
+            <div>Server</div>
+            <div>Configuration</div>
+            <div>Production:</div>
+            <div>
               <input type="radio"
                      id="use-prod-main"
                      name="server-radio"
                      value="prod-main"
                      checked/>
               <label for="use-prod-main">Active</label>
-            </span>
-          </td>
-          <td>
-            <input type="radio"
-                   id="use-prod-preview"
-                   name="server-radio"
-                   value="prod-preview"/>
-            <label for="use-prod-preview">In Review</label>
-          </td>
-        </tr>
-        <tr>
-          <td>Staging:</td>
-          <td>
-            <span class="radio">
+            </div>
+            <div>
+              <input type="radio"
+                     id="use-prod-preview"
+                     name="server-radio"
+                     value="prod-preview"/>
+              <label for="use-prod-preview">In Review</label>
+            </div>
+            <div>Staging:</div>
+            <div>
               <input type="radio"
                      id="use-stage-main"
                      name="server-radio"
                      value="stage-main"/>
               <label for="use-stage-main">Active</label>
-            </span>
-          </td>
-          <td>
-            <input type="radio"
-                   id="use-stage-preview"
-                   name="server-radio"
-                   value="stage-preview"/>
-            <label for="use-stage-preview">In Review</label>
-          </td>
-        </tr>
-      </table>
-      <div id="reload-div">
-        <button id="reload-page">Clear Cache & Reload Page</button>
+            </div>
+            <div>
+              <input type="radio"
+                     id="use-stage-preview"
+                     name="server-radio"
+                     value="stage-preview"/>
+              <label for="use-stage-preview">In Review</label>
+            </div>
+            <div>Local:</div>
+            <div>
+              <input type="radio"
+                     id="use-local-text"
+                     name="server-radio"
+                     value="local-text"/>
+              <label for="use-local-text">Use config from textbox</label>
+            </div>
+          </div>
+        </fieldset>
+        <div id="configuration">
+          <textarea id="config"></textarea>
+        </div>
+        <fieldset id="compare-with" hidden="true">
+          <legend>Compare With</legend>
+          <div id="compare-settings" class="server-settings-table">
+            <div>Server</div>
+            <div>Configuration</div>
+            <div>Production:</div>
+            <div>
+              <input type="radio"
+                     id="config-use-prod-main"
+                     name="config-radio"
+                     value="prod-main"/>
+              <label for="config-use-prod-main">Active</label>
+            </div>
+            <div>
+              <input type="radio"
+                     id="config-use-prod-preview"
+                     name="config-radio"
+                     value="prod-preview"
+                     checked/>
+              <label for="config-use-prod-preview">In Review</label>
+            </div>
+            <div>Staging:</div>
+            <div>
+              <input type="radio"
+                     id="config-use-stage-main"
+                     name="config-radio"
+                     value="stage-main"/>
+              <label for="config-use-stage-main">Active</label>
+            </div>
+            <div>
+              <input type="radio"
+                     id="config-use-stage-preview"
+                     name="config-radio"
+                     value="stage-preview"/>
+              <label for="config-use-stage-preview">In Review</label>
+            </div>
+            <div>Local:</div>
+            <div>
+              <input type="radio"
+                     id="config-use-local-text"
+                     name="config-radio"
+                     value="local-text"/>
+              <label for="config-use-local-text">Use config from textbox</label>
+            </div>
+          </div>
+        </fieldset>
+        <div id="reload-div">
+          <button id="reload-page">Use these servers/configuration</button>
+        </div>
       </div>
-    </div>
-    <div id="configuration">
-      <textarea id="config"></textarea>
-      <button id="reload-engines">Use this Schema and Reload Engines</button>
-    </div>
-
-  </fieldset>
-
-  <section id="engines">
-    <div id="tabs">
-      <button id="by-locales">Engines by locale/region</button>
-      <button id="by-engine">Locale/region by Engine</button>
-    </div>
 
     <div id="tab-contents">
       <div id="by-locales-tab">
@@ -138,12 +181,25 @@
         <div id="locale-region-results">
         </div>
       </div>
+      <div id="compare-configs-tab">
+        <div>
+          <div id="overview">
+            <label for="changed-sections">Changed engines:</label>
+            <div>
+              <select id="changed-sections" multiple size="4"></select>
+            </div>
+          </div>
+          <div id="diff-display">
+          </div>
+        </div>
+      </div>
     </div>
   </section>
 </form>
 
 </body>
 
+<script type="text/javascript" src="diff.min.js"></script>
 <script type="text/javascript" src="script.js"></script>
 
 </html>

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -37,19 +37,43 @@ h1, h2, h3, h4 {
   margin-top: 0;
 }
 
-#settings {
-  display: grid;
-  grid: auto-flow / max-content 1fr;
+#settings, #compare-with {
+  padding: 1em 0.5em;
+  width: max-content;
 }
 
-#settings {
-  padding: 1em 0.5em;
+#engines {
+  display: flex;
+  flex-direction: column;
+  margin: 15px 0;
+  padding: 0 15px;
+}
+
+#engines p {
+  color: var(--in-content-deemphasized-text);
+}
+
+#tabs {
+  display: grid;
+  grid: auto-flow / 1fr 1fr 1fr;
+  margin: 0 -15px;
+  padding-bottom: 15px;
+}
+
+#server-settings {
+  display: grid;
+  grid-template-columns: max-content auto;
+}
+
+#compare-with[hidden] {
+  display: none;
 }
 
 #configuration {
+  grid-column: 2 / 3;
+  grid-row: 1 / 4;
   display: flex;
   flex-direction: column;
-  height: 15em;
   padding-left: 0.5em;
 }
 
@@ -63,32 +87,17 @@ h1, h2, h3, h4 {
   margin: auto;
 }
 
-#engines {
-  display: flex;
-  flex-direction: column;
-  padding: 0;
-}
-
-#engines p {
-  color: var(--in-content-deemphasized-text);
-}
-
-#tabs {
-  display: grid;
-  grid: auto-flow / 1fr 1fr;
-}
-
-#by-engine, #by-locales {
+#by-engine, #by-locales, #compare-configs {
   margin: 0;
   padding: 0;
   background-color: var(--in-content-button-background);
 }
 
-#by-engine[selected], #by-locales[selected] {
+#by-engine[selected], #by-locales[selected], #compare-configs[selected] {
   background-color: transparent;
 }
 
-#by-engine:hover, #by-locales:hover {
+#by-engine:hover, #by-locales:hover, #compare-configs:hover {
   background-color: var(--in-content-button-background-hover);
 }
 
@@ -98,11 +107,11 @@ h1, h2, h3, h4 {
   min-height: 32em;
 }
 
-#by-locales-tab, #by-engine-tab {
+#by-locales-tab, #by-engine-tab, #compare-configs-tab {
   display: none;
 }
 
-#by-locales-tab[selected], #by-engine-tab[selected] {
+#by-locales-tab[selected], #by-engine-tab[selected], #compare-configs-tab[selected] {
   display: block;
 }
 
@@ -121,10 +130,6 @@ h1, h2, h3, h4 {
 
 #locale-region-settings label {
   display: block;
-}
-
-#engines {
-  margin: 15px 0px;
 }
 
 #engines-table {
@@ -175,13 +180,39 @@ h1, h2, h3, h4 {
   line-height: 20px;
 }
 
-#server-settings > table {
+.server-settings-table {
+  display: grid;
+  grid-template-columns: repeat(3, max-content);
+}
+
+.server-settings-table > div {
+  border: 1px solid var(--in-content-border-color);
+  padding: .3em 1em;
+  margin-left: -1px;
+  margin-bottom: -1px;
+}
+
+.server-settings-table > div:nth-child(2) {
+  grid-column: 2 / 4;
+}
+
+.server-settings-table > div:nth-child(-n+2) {
+  font-weight: bold;
+  text-align: center;
+  padding-bottom: .5em;
+}
+
+.server-settings-table > div:nth-child(10) {
+  grid-column: 2 / 4;
+}
+
+fieldset > div > table {
   border-collapse: collapse;
 }
 
-#server-settings > table,
-#server-settings th,
-#server-settings td {
+fieldset > div > table,
+fieldset > div th,
+fieldset > div td {
   border: 1px solid var(--in-content-border-color);
   padding: .3em 1em;
 }
@@ -227,4 +258,22 @@ h1, h2, h3, h4 {
 #locale-region-results > div:nth-child(2n+3):nth-child(4n+3),
 #locale-region-results > div:nth-child(2n+4):nth-child(4n+4) {
   background: var(--in-content-box-background-odd);
+}
+
+#overview {
+  display: flex;
+}
+
+#overview > label {
+  margin: auto 0;
+  padding: 1ch;
+}
+
+#diff-display {
+  margin: 1ch 0;
+  font-size: 12px;
+}
+
+#diff-display > pre {
+  margin: 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2104,6 +2104,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "dispensary": {
       "version": "0.49.0",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "dependencies": {
+    "diff": "4.0.2",
     "web-ext": "^4.0.0"
   },
   "devDependencies": {
@@ -18,8 +19,8 @@
   },
   "scripts": {
     "test": "eslint .",
-    "build": "web-ext build -s ./extension/ --overwrite-dest",
-    "start": "web-ext run --source-dir ./extension/"
+    "build": "cp node_modules/diff/dist/diff.min.js extension/content/ && web-ext build -s ./extension/ --overwrite-dest",
+    "start": "cp node_modules/diff/dist/diff.min.js extension/content/ && web-ext run --source-dir ./extension/"
   },
   "private": true,
   "license": "MPLv2"


### PR DESCRIPTION
This adds a new view which provides a comparison between different servers.

I've relaid out the page, as it ended up making more sense to move the tabs to the top, and re-arrange the layout.

At the moment I've broken the using the local configuration, I removed the separate button, so we probably need to rework how we're loading and caching things. I'm hoping to get those fixed soon, but I need to do other things for the next day or so, but would like to get the review process started for the work so far.