### PR TITLE
Bug 1641610 - Add an update mechanism.

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,13 +1,14 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
 
   "applications": {
     "gecko": {
-      "id": "searchengines-devtools@mozilla.com"
+      "id": "searchengines-devtools@mozilla.com",
+      "update_url": "https://raw.githubusercontent.com/mozilla-extensions/searchengine-devtools/master/update.json"
     }
   },
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "dependencies": {

--- a/update.json
+++ b/update.json
@@ -1,0 +1,12 @@
+{
+  "addons": {
+    "searchengines-devtools@mozilla.com": {
+      "updates": [
+        {
+          "version": "1.1.2",
+          "update_link": "https://github.com/mozilla-extensions/searchengine-devtools/releases/download/1.1.2/searchengine-devtools-1.1.2.xpi"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
This adds an update url pointing to master for the update.json.

Also an update.json with a record in, this won't be used for the initial release that contains the update url, but contains the template for the next release.