### PR TITLE
Bug 1656532 - Extend searchengine-devtools to allow entering the experiment ID.

### DIFF
--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -121,12 +121,12 @@
     <div id="tab-contents">
       <div id="by-locales-tab">
         <fieldset id="locale-region-settings">
-          <div>
+          <div id="region-select-wrapper">
             <label for="region-select">Region</label>
             <select id="region-select" multiple size="4"></select>
           </div>
 
-          <div>
+          <div id="locale-select-wrapper">
             <label for="locale-select">Locale</label>
             <select id="locale-select" multiple size="4"></select>
           </div>
@@ -134,6 +134,11 @@
           <div>
             <label for="distro-id">Distribution ID</label>
             <input id="distro-id" type="text" />
+          </div>
+
+          <div>
+            <label for="experiment-id">Experiment ID (81.0a1+)</label>
+            <input id="experiment-id" type="text" />
           </div>
         </fieldset>
 

--- a/extension/content/script.js
+++ b/extension/content/script.js
@@ -39,12 +39,14 @@ async function loadEngines() {
   let locale = $("#locale-select").value;
   let region = $("#region-select").value;
   let distroID = $("#distro-id").value;
-  let { engines, private } = await searchengines.getEngines(
-    $("#config").value,
+  let experiment = $("#experiment-id").value;
+  let { engines, private } = await searchengines.getEngines({
+    configUrl: $("#config").value,
     locale,
     region,
-    distroID
-  );
+    distroID,
+    experiment,
+  });
 
   function getTelemetryId(e) {
     // Based on SearchService.getEngineParams().
@@ -123,6 +125,7 @@ async function initUI() {
   $("#region-select").addEventListener("change", reloadEngines);
   $("#locale-select").addEventListener("change", reloadEngines);
   $("#distro-id").addEventListener("input", reloadEngines);
+  $("#experiment-id").addEventListener("input", reloadEngines);
   $("#engine-id").addEventListener("change", calculateLocaleRegions);
   $("#engine-telemetry-id").addEventListener("change", calculateLocaleRegions);
   $("#locale-by-engine").addEventListener("change", calculateLocaleRegions);

--- a/extension/content/style.css
+++ b/extension/content/style.css
@@ -116,11 +116,18 @@ h1, h2, h3, h4 {
 }
 
 #locale-region-settings {
-  display: flex;
+  display: grid;
   justify-content: space-between;
   align-items: center;
   width: max-content;
   margin: 0 auto;
+  grid-template-columns: repeat(3, auto);
+  grid-template-rows: repeat(2, auto);
+}
+
+#region-select-wrapper,
+#locale-select-wrapper {
+  grid-row: 1 / 3;
 }
 
 #locale-region-settings div {

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -30,21 +30,30 @@
         "description": "Return the engine configuration for the given region, locale and configuration",
         "async": true,
         "parameters": [{
-          "name": "configUrl",
-          "description": "The configuration",
-          "type": "string"
-        }, {
-          "name": "locale",
-          "description": "The users locale",
-          "type": "string"
-        }, {
-          "name": "region",
-          "description": "The users region",
-          "type": "string"
-        }, {
-          "name": "distroID",
-          "description": "The user's distribution",
-          "type": "string"
+          "type": "object",
+          "name": "getEnginesProperties",
+          "properties": {
+            "configUrl": {
+              "type": "string",
+              "description": "The configuration"
+            },
+            "locale" : {
+              "type": "string",
+              "description": "The users locale"
+            },
+            "region": {
+              "type": "string",
+              "description": "The users region"
+            },
+            "distroID": {
+              "type": "string",
+              "description": "The user's distribution"
+            },
+            "experiment": {
+              "type": "string",
+              "description": "The user's experiment id"
+            }
+          }
         }]
       }
     ],

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "dependencies": {

--- a/update.json
+++ b/update.json
@@ -3,8 +3,8 @@
     "searchengines-devtools@mozilla.com": {
       "updates": [
         {
-          "version": "1.1.3",
-          "update_link": "https://github.com/mozilla-extensions/searchengine-devtools/releases/download/1.1.3/searchengine-devtools-1.1.3.xpi"
+          "version": "1.1.4",
+          "update_link": "https://github.com/mozilla-extensions/searchengine-devtools/releases/download/1.1.4/searchengine-devtools-1.1.4.xpi"
         }
       ]
     }


### PR DESCRIPTION
This also allows fallback to the old version of the API for backwards compatibility.