### PR TITLE
Add mozillaAddons to permissions and bump versions for 1.1.8

### DIFF
--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
 
@@ -22,6 +22,7 @@
   },
 
   "permissions": [
+    "mozillaAddons",
     "https://firefox.settings.services.mozilla.com/*",
     "https://settings.stage.mozaws.net/*",
     "https://hg.mozilla.org/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "1.1.7",
+  "version": "1.1.8",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "webExt": {


### PR DESCRIPTION
Adding the "mozillaAddons" permissions as required by recent add-on changes, also bumping to 1.1.8 so that we can release the recent schema updates.