### PR TITLE
Bug 1777943 - Avoid unnecessarily importing XPCOMUtils and Services since the WebExtension Experiments API has already defined these.

### DIFF
--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -2,14 +2,9 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* global ExtensionAPI */
-
-const { XPCOMUtils } = ChromeUtils.import(
-  "resource://gre/modules/XPCOMUtils.jsm"
-);
+/* global ExtensionAPI, XPCOMUtils, Services */
 
 XPCOMUtils.defineLazyModuleGetters(this, {
-  Services: "resource://gre/modules/Services.jsm",
   SearchEngineSelector: "resource://gre/modules/SearchEngineSelector.jsm",
 });
 


### PR DESCRIPTION
According to [bug 1667455 comment 41](https://bugzilla.mozilla.org/show_bug.cgi?id=1667455#c41), the `Services` global was exposed to WebExtension experiment API code in Firefox 88. This means that we no longer need to import it. Likewise, we can do the same with `XPCOMUtils`.

We'll need to use these globals to help to avoid breakage as the import rework starts to land.