### PR TITLE
Update Remote Settings URLs after GCP migration

### DIFF
--- a/extension/content/script.mjs
+++ b/extension/content/script.mjs
@@ -24,9 +24,9 @@ const ENGINES_URLS = {
   "prod-preview":
     "https://firefox.settings.services.mozilla.com/v1/buckets/main-preview/collections/search-config/records?_cachebust=%CACHEBUST%",
   "stage-main":
-    "https://settings.stage.mozaws.net/v1/buckets/main/collections/search-config/records?_cachebust=%CACHEBUST%",
+    "https://firefox.settings.services.allizom.org/v1/buckets/main/collections/search-config/records?_cachebust=%CACHEBUST%",
   "stage-preview":
-    "https://settings.stage.mozaws.net/v1/buckets/main-preview/collections/search-config/records?_cachebust=%CACHEBUST%",
+    "https://firefox.settings.services.allizom.org/v1/buckets/main-preview/collections/search-config/records?_cachebust=%CACHEBUST%",
 };
 
 async function main() {

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -20,7 +20,7 @@
   "permissions": [
     "mozillaAddons",
     "https://firefox.settings.services.mozilla.com/*",
-    "https://settings.stage.mozaws.net/*",
+    "https://firefox.settings.services.allizom.org/*",
     "https://hg.mozilla.org/"
   ],
   "icons": {

--- a/scripts/upload.py
+++ b/scripts/upload.py
@@ -7,9 +7,9 @@ import requests
 import sys
 
 API_ENDPOINTS = {
-    'dev': "https://kinto.dev.mozaws.net/v1/",
-    'stage': "https://settings-writer.stage.mozaws.net/v1/",
-    'prod': "https://settings-writer.prod.mozaws.net/v1/"
+    'dev': "https://remote-settings-dev.allizom.org/v1/",
+    'stage': "https://remote-settings.allizom.org/v1/",
+    'prod': "https://remote-settings.mozilla.org/v1/"
 }
 
 parser = argparse.ArgumentParser(


### PR DESCRIPTION
Supports https://mozilla-hub.atlassian.net/browse/OPST-962 and https://mozilla-hub.atlassian.net/browse/OPST-977