### PR TITLE
fix: Add basic support for search-config-overrides(-v2).

### DIFF
--- a/extension/content/byEngineView.mjs
+++ b/extension/content/byEngineView.mjs
@@ -124,7 +124,7 @@ export default class ByEngineView extends HTMLElement {
     const byLength = allBy.length;
     // Pre-filter the config for just the engine id to reduce the amount of
     // processing to do.
-    const configUrl = this.#filterConfig(config, engineId);
+    const configData = this.#filterConfig(config, engineId);
 
     let count = 0;
     const results = new Map();
@@ -133,7 +133,9 @@ export default class ByEngineView extends HTMLElement {
       const itemResults = new Set();
       for (const subItem of allSub) {
         const { engines } = await browser.experiments.searchengines.getEngines({
-          configUrl,
+          configData,
+          // No need to apply the overrides for this view.
+          configOverridesData: '{"data":[]}',
           locale: byLocale ? item : subItem,
           region: byLocale ? subItem : item,
           distroID: "",

--- a/extension/content/byEngineViewOld.mjs
+++ b/extension/content/byEngineViewOld.mjs
@@ -124,7 +124,7 @@ export default class ByEngineViewOld extends HTMLElement {
     const byLength = allBy.length;
     // Pre-filter the config for just the engine id to reduce the amount of
     // processing to do.
-    const configUrl = this.#filterConfig(config, engineId);
+    const configData = this.#filterConfig(config, engineId);
 
     let count = 0;
     const results = new Map();
@@ -133,7 +133,9 @@ export default class ByEngineViewOld extends HTMLElement {
       const itemResults = new Set();
       for (const subItem of allSub) {
         const { engines } = await browser.experiments.searchengines.getEngines({
-          configUrl,
+          configData,
+          // No need to apply the overrides for this view.
+          configOverridesData: '{"data":[]}',
           locale: byLocale ? item : subItem,
           region: byLocale ? subItem : item,
           distroID: "",

--- a/extension/content/configController.mjs
+++ b/extension/content/configController.mjs
@@ -100,6 +100,15 @@ export default class ConfigController extends HTMLElement {
     return fetchCached(await this.#getEngineUrl(buttonValue));
   }
 
+  async fetchConfigOverrides() {
+    const buttonValue =
+      this.shadowRoot.getElementById(`primary-config`).selected;
+    if (buttonValue == "local-text") {
+      return '{"data":[]}';
+    }
+    return fetchCached(await this.#getEngineUrl(buttonValue, true));
+  }
+
   async getAttachmentBaseUrl() {
     const buttonValue =
       this.shadowRoot.getElementById(`primary-config`).selected;
@@ -143,8 +152,11 @@ export default class ConfigController extends HTMLElement {
     textarea.scrollTop = line * parseInt(lineHeight, 10);
   }
 
-  async #getEngineUrl(server) {
-    let url = this.#getConfigUrl(server) + "collections/search-config";
+  async #getEngineUrl(server, overrides) {
+    let url =
+      this.#getConfigUrl(server) +
+      "collections/search-config" +
+      (overrides ? "-overrides" : "");
 
     if (
       (await browser.experiments.searchengines.getCurrentConfigFormat()) == "2"

--- a/extension/content/enginesViewOld.mjs
+++ b/extension/content/enginesViewOld.mjs
@@ -3,7 +3,12 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import Utils from "./utils.mjs";
-import { getLocales, getRegions, validateConfiguration } from "./loader.mjs";
+import {
+  getLocales,
+  getRegions,
+  validateConfiguration,
+  validateConfigurationOverrides,
+} from "./loader.mjs";
 
 const enginesSelectionElements = [
   "region-select",
@@ -15,6 +20,7 @@ const enginesSelectionElements = [
 
 export default class EnginesViewOld extends HTMLElement {
   #config = null;
+  #configOverrides = null;
   #initializedPromise = null;
 
   constructor() {
@@ -69,25 +75,31 @@ export default class EnginesViewOld extends HTMLElement {
     }
   }
 
-  async loadEngines(event, config) {
+  async loadEngines(event, config, configOverrides) {
     if (event) {
       event.preventDefault();
     }
     await this.initialize();
 
     if (config) {
-      if (!(await validateConfiguration(JSON.parse(config)))) {
+      if (
+        !(await validateConfiguration(JSON.parse(config))) ||
+        !(await validateConfigurationOverrides(JSON.parse(configOverrides)))
+      ) {
         this.#config = null;
+        this.#configOverrides = null;
         throw new Error("Invalid Config");
       }
       this.#config = config;
+      this.#configOverrides = configOverrides;
     }
     if (!this.#config) {
       return;
     }
 
     let options = {
-      configUrl: this.#config,
+      configData: this.#config,
+      configOverridesData: this.#configOverrides,
       locale: this.shadowRoot.getElementById("locale-select").value,
       region: this.shadowRoot.getElementById("region-select").value,
       distroID: this.shadowRoot.getElementById("distro-id").value,

--- a/extension/content/loader.mjs
+++ b/extension/content/loader.mjs
@@ -45,16 +45,30 @@ export async function validateConfiguration(config) {
     (await browser.experiments.searchengines.getCurrentConfigFormat()) == "2"
       ? validate.validateWithSchemaV2
       : validate.validateWithSchemaV1;
+
+  return validateCollectionToSchema(validator, config);
+}
+
+export async function validateConfigurationOverrides(overrides) {
+  let validator =
+    (await browser.experiments.searchengines.getCurrentConfigFormat()) == "2"
+      ? validate.validateWithOverridesSchemaV2
+      : validate.validateWithOverridesSchemaV1;
+
+  return validateCollectionToSchema(validator, overrides);
+}
+
+function validateCollectionToSchema(validator, collection) {
   let valid = true;
 
-  if (!("data" in config)) {
+  if (!("data" in collection)) {
     console.error("Could not find top-level 'data' property in config.");
     valid = false;
     return false;
   }
 
   try {
-    for (let item of config.data) {
+    for (let item of collection.data) {
       if (!validator(item)) {
         for (let error of validator.errors) {
           console.warn(error);

--- a/extension/content/script.mjs
+++ b/extension/content/script.mjs
@@ -168,6 +168,7 @@ async function setupEnginesView() {
   await $("#engines-view").loadEngines(
     null,
     await $("#config-controller").fetchPrimaryConfig(),
+    await $("#config-controller").fetchConfigOverrides(),
     await $("#config-controller").getAttachmentBaseUrl(),
     await $("#config-controller").fetchIconConfig()
   );

--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -58,12 +58,17 @@ async function getEngines(options) {
   }
 
   engineSelector.getEngineConfiguration = async () => {
-    const result = JSON.parse(options.configUrl).data;
+    let config = JSON.parse(options.configData).data;
     if (!usingV2) {
-      result.sort((a, b) => a.id.localeCompare(b.id));
+      config.sort((a, b) => a.id.localeCompare(b.id));
     }
-    engineSelector._configuration = result;
-    return result;
+    engineSelector._configuration = config;
+
+    engineSelector._configurationOverrides = JSON.parse(
+      options.configOverridesData
+    ).data;
+
+    return config;
   };
   return engineSelector.fetchEngineConfiguration(options);
 }

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -41,9 +41,13 @@
             "type": "object",
             "name": "getEnginesProperties",
             "properties": {
-              "configUrl": {
+              "configData": {
                 "type": "string",
-                "description": "The configuration"
+                "description": "The configuration to use (a JSON string)"
+              },
+              "configOverridesData": {
+                "type": "string",
+                "description": "The configuration overrides to use (a JSON string)"
               },
               "locale": {
                 "type": "string",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "webExt": {

--- a/schemas/generateValidator.js
+++ b/schemas/generateValidator.js
@@ -17,11 +17,22 @@ let schemaV2 = JSON.parse(
   fs.readFileSync(path.join(__dirname, "search-config-v2-schema.json"))
 );
 
+let schemaOverridesV1 = JSON.parse(
+  fs.readFileSync(path.join(__dirname, "search-config-overrides-schema.json"))
+);
+let schemaOverridesV2 = JSON.parse(
+  fs.readFileSync(
+    path.join(__dirname, "search-config-overrides-v2-schema.json")
+  )
+);
+
 schemaV1.$id = "validateWithSchemaV1";
 schemaV2.$id = "validateWithSchemaV2";
+schemaOverridesV1.$id = "validateWithOverridesSchemaV1";
+schemaOverridesV2.$id = "validateWithOverridesSchemaV2";
 
 const ajv = new Ajv({
-  schemas: [schemaV1, schemaV2],
+  schemas: [schemaV1, schemaV2, schemaOverridesV1, schemaOverridesV2],
   code: { source: true },
 });
 addFormats(ajv);

--- a/schemas/search-config-overrides-schema.json
+++ b/schemas/search-config-overrides-schema.json
@@ -1,0 +1,64 @@
+{
+  "title": "Search Engine Overrides Schema",
+  "description": "This schema contains the details for overriding application provided search engines defined in search-config. The associated remote settings collection is search-config-overrides.",
+  "type": "object",
+  "required": ["telemetryId"],
+  "properties": {
+    "telemetryId": {
+      "type": "string",
+      "title": "Telemetry Id",
+      "description": "The telemetry Id used to match the engine that this record will override.",
+      "pattern": "^[a-zA-Z0-9-$_]{0,100}$"
+    },
+    "params": {
+      "$ref": "#/definitions/params"
+    },
+    "clickUrl": {
+      "type": "string",
+      "format": "uri",
+      "description": "The url used to for reporting clicks."
+    },
+    "telemetrySuffix": {
+      "type": "string",
+      "title": "Telemetry Suffix",
+      "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`.",
+      "pattern": "^[a-zA-Z0-9-]*$"
+    }
+  },
+  "definitions": {
+    "searchUrlCodes": {
+      "type": "array",
+      "title": "Codes",
+      "description": "A array of objects - map of parameter name to the parameter value.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+            "title": "Name",
+            "pattern": "^[a-zA-Z0-9.-]{0,100}$",
+            "description": "Name of the parameter that will be used in the query"
+          },
+          "value": {
+            "type": "string",
+            "title": "Value",
+            "pattern": "^[a-zA-Z0-9_{}:/.-]{0,100}$",
+            "description": "The value of parameter (pref or purpose)"
+          }
+        }
+      }
+    },
+    "params": {
+      "type": "object",
+      "title": "Parameters",
+      "description": "Various parameters for the search engines",
+      "properties": {
+        "searchUrlGetParams": {
+          "title": "Search URL GET Parameters",
+          "description": "Extra parameters for search URLs (e.g. 'pc=foo').",
+          "$ref": "#/definitions/searchUrlCodes"
+        }
+      }
+    }
+  }
+}

--- a/schemas/search-config-overrides-v2-schema.json
+++ b/schemas/search-config-overrides-v2-schema.json
@@ -1,0 +1,79 @@
+{
+  "title": "Search Engine Overrides Schema",
+  "description": "This schema contains the details for overriding application provided search engines defined in search-config-v2. The associated remote settings collection is search-config-overrides-v2.",
+  "definitions": {
+    "partnerCode": {
+      "title": "Partner Code",
+      "description": "The partner code for the engine or variant. This will be inserted into parameters which include '{partnerCode}'",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9-_]*$"
+    },
+    "urls": {
+      "title": "URLs",
+      "description": "The URLs associated with the search engine.",
+      "type": "object",
+      "properties": {
+        "search": {
+          "title": "Search URL",
+          "description": "The URL to use for searches",
+          "$ref": "#/definitions/url"
+        }
+      }
+    },
+    "url": {
+      "type": "object",
+      "properties": {
+        "base": {
+          "title": "Base",
+          "description": "The PrePath and FilePath of the URL. May include variables for engines which have a variable FilePath, e.g. {searchTerm} for when a search term is within the path of the url.",
+          "type": "string"
+        },
+        "params": {
+          "title": "Parameters",
+          "description": "The parameters for this URL.",
+          "type": "array",
+          "items": {
+            "type": "object",
+            "title": "Parameter",
+            "properties": {
+              "name": {
+                "title": "Name",
+                "description": "The parameter name",
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-_]*$"
+              },
+              "value": {
+                "title": "Value",
+                "description": "The parameter value, this may be a static value, or additionally contain a parameter replacement, e.g. {inputEncoding}. For the partner code parameter, this field should be {pc}.",
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-_{}]*$"
+              }
+            },
+            "required": ["name", "value"]
+          }
+        }
+      }
+    }
+  },
+  "type": "object",
+  "properties": {
+    "identifier": {
+      "title": "Identifier",
+      "description": "This is the identifier of the search engine in search-config-v2 that this record will override. It may be extended by telemetrySuffix.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9-_]*$"
+    },
+    "partnerCode": {
+      "$ref": "#/definitions/partnerCode"
+    },
+    "telemetrySuffix": {
+      "title": "Telemetry Suffix",
+      "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`. There should always be a suffix supplied if the partner code is different.",
+      "type": "string",
+      "pattern": "^[a-zA-Z0-9-]*$"
+    },
+    "urls": {
+      "$ref": "#/definitions/urls"
+    }
+  }
+}


### PR DESCRIPTION
This adds support for the new search-config-overrides collections.

At the moment, I'm not adding options to be able to change the overrides collection - only apply what is received from the servers, or nothing if you're testing a local config.

I think this will be good enough for now, and we can add options to not apply the overrides or to be able to edit it later on.