### PR TITLE
Update search-config-v2 schemas and stop allowing multiple selection of the application name

### DIFF
--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -128,7 +128,7 @@
 
         <div id="application-name-wrapper">
           <label for="application-name">Application</label>
-          <select id="application-name" multiple size="5">
+          <select id="application-name" size="5">
             <option value="firefox" selected>Firefox</option>
             <option value="firefox-android">Firefox (Android)</option>
             <option value="focus-android">Focus (Android)</option>
@@ -170,7 +170,7 @@
 
         <div id="application-name-wrapper">
           <label for="application-name">Application</label>
-          <select id="application-name" multiple size="5">
+          <select id="application-name" size="5">
             <option value="firefox" selected>Firefox</option>
           </select>
         </div>
@@ -222,7 +222,7 @@
         </div>
         <div id="application-name-wrapper">
           <label for="application-name">Application Name</label>
-          <select id="application-name" multiple size="5">
+          <select id="application-name" size="5">
             <option value="firefox" selected>Firefox</option>
             <option value="firefox-android">Firefox (Android)</option>
             <option value="focus-android">Focus (Android)</option>
@@ -274,7 +274,7 @@
         <div id="application-name-wrapper">
           <label for="application-name">Application Name</label>
           <div>
-            <select id="application-name" multiple size="5">
+            <select id="application-name" size="5">
               <option value="firefox" selected>Firefox</option>
             </select>
           </div>

--- a/schemas/search-config-v2-schema.json
+++ b/schemas/search-config-v2-schema.json
@@ -108,7 +108,6 @@
             "type": "string",
             "pattern": "^[a-z-]{0,100}$",
             "enum": [
-              "",
               "firefox",
               "firefox-android",
               "firefox-ios",
@@ -129,12 +128,23 @@
           "description": "The maximum application version this section applies to (less-than comparison).",
           "type": "string",
           "pattern": "^[0-9a-z.]{0,20}$"
+        },
+        "mobileLayout": {
+          "title": "Mobile Layout",
+          "description": "The layouts(s) this section applies to (default/not specified is any layout). On desktop when this property is specified and non-empty, the associated section will be ignored.",
+          "type": "array",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z-]{0,100}$",
+            "enum": ["smartphone", "tablet"]
+          },
+          "uniqueItems": true
         }
       }
     },
     "partnerCode": {
       "title": "Partner Code",
-      "description": "The partner code for the engine or variant. This will be inserted into parameters which include '{pc}'",
+      "description": "The partner code for the engine or variant. This will be inserted into parameters which include '{partnerCode}'",
       "type": "string",
       "pattern": "^[a-zA-Z0-9-_]*$"
     },
@@ -191,7 +201,7 @@
               },
               "value": {
                 "title": "Value",
-                "description": "The parameter value, this may be a static value, or additionally contain a parameter replacement, e.g. {inputEncoding}. For the partner code parameter, this field should be {pc}.",
+                "description": "The parameter value, this may be a static value, or additionally contain a parameter replacement, e.g. {inputEncoding}. For the partner code parameter, this field should be {partnerCode}.",
                 "type": "string",
                 "pattern": "^[a-zA-Z0-9-_{}]*$"
               },
@@ -316,11 +326,6 @@
                 "type": "string",
                 "maxLength": 100
               },
-              "optional": {
-                "title": "Optional",
-                "description": "This search engine is presented as an option that the user may enable. It is not included in the initial list of search engines. If not specified, defaults to false.",
-                "type": "boolean"
-              },
               "partnerCode": {
                 "$ref": "#/definitions/partnerCode"
               },
@@ -332,7 +337,7 @@
           },
           "variants": {
             "title": "Variants",
-            "description": "This section describes variations of this search engine that may occur depending on the user's environment. If multiple sections match a user's environment, then all matching sections are applied cumulatively in the order in the array.",
+            "description": "This section describes variations of this search engine that may occur depending on the user's environment. The last variant that matches the user's environment will be applied to the engine, subvariants may also be applied.",
             "type": "array",
             "items": {
               "type": "object",
@@ -343,20 +348,53 @@
                 "partnerCode": {
                   "$ref": "#/definitions/partnerCode"
                 },
+                "optional": {
+                  "title": "Optional",
+                  "description": "This search engine is presented as an option that the user may enable. It is not included in the initial list of search engines. If not specified, defaults to false.",
+                  "type": "boolean"
+                },
                 "telemetrySuffix": {
                   "title": "Telemetry Suffix",
-                  "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`. There should always be a suffix supplied if the partner code is different.",
+                  "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`. There should always be a suffix supplied if the partner code is different for a reason other than being on a different platform.",
                   "type": "string",
                   "pattern": "^[a-zA-Z0-9-]*$"
                 },
                 "urls": {
                   "$ref": "#/definitions/urls"
+                },
+                "subVariants": {
+                  "title": "Subvariants",
+                  "description": "This section describes subvariations of this search engine that may occur depending on the user's environment. The last subvariant that matches the user's environment will be applied to the engine.",
+                  "type": "array",
+                  "items": {
+                    "type": "object",
+                    "properties": {
+                      "environment": {
+                        "$ref": "#/definitions/environment"
+                      },
+                      "partnerCode": {
+                        "$ref": "#/definitions/partnerCode"
+                      },
+                      "optional": {
+                        "title": "Optional",
+                        "description": "This search engine is presented as an option that the user may enable. It is not included in the initial list of search engines. If not specified, defaults to false.",
+                        "type": "boolean"
+                      },
+                      "telemetrySuffix": {
+                        "title": "Telemetry Suffix",
+                        "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`. There should always be a suffix supplied if the partner code is different for a reason other than being on a different platform.",
+                        "type": "string",
+                        "pattern": "^[a-zA-Z0-9-]*$"
+                      },
+                      "urls": {
+                        "$ref": "#/definitions/urls"
+                      }
+                    },
+                    "required": ["environment"]
+                  }
                 }
               },
-              "required": ["environment"],
-              "dependencies": {
-                "partnerCode": ["telemetrySuffix"]
-              }
+              "required": ["environment"]
             }
           }
         },


### PR DESCRIPTION
We've a few schema updates that we need to get into the devtools to allow it to keep working with the new schemas.

Also fixing the selection of the application name, which shouldn't allow multiple selection.