### PR TITLE
fix: When using search-config-v2 make the order of engines behave the same as desktop (bug 1895740)

### DIFF
--- a/extension/content/loader.mjs
+++ b/extension/content/loader.mjs
@@ -30,6 +30,7 @@ export async function getLocales() {
       .filter((e) => e.match(/^[a-zA-Z-]+$/)),
     "en-US",
   ];
+  // Convert ja-JP-mac to BCP47 standard.
   locales = locales.map((l) => (l == "ja-JP-mac" ? "ja-JP-macos" : l));
   return locales.sort();
 }

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -34,7 +34,7 @@
       {
         "name": "getEngines",
         "type": "function",
-        "description": "Return the engine configuration for the given region, locale and configuration",
+        "description": "Return the sorted engine configuration for the given region, locale and configuration",
         "async": true,
         "parameters": [
           {


### PR DESCRIPTION
This adds search order handling to be the same as desktop. It is possible that we could move desktop's sort function to a function that we could call from the extension as well - but we would still need a fallback (at least in the short term) for the current versions of FF, and overall, I'm not sure if it is worth it as it isn't something we generally update.

