### PR TITLE
Add table to display engine search, suggest, and trending URLs.

### DIFF
--- a/extension/content/engineUrlView.css
+++ b/extension/content/engineUrlView.css
@@ -1,0 +1,35 @@
+/* Set the general styling for the table */
+#engine-urls-table table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 20px 0;
+  font-size: 1rem;
+  text-align: center;
+  border: 1px solid lightgray;
+}
+
+/* Style for the table headers */
+#engine-urls-table th {
+  padding: 10px;
+  border: 1px solid lightgray;
+}
+
+/* Style for the table cells */
+#engine-urls-table td {
+  padding: 10px;
+  border: 1px solid lightgray;
+}
+
+/* Zebra striping for table rows */
+#engine-urls-table tbody tr:nth-child(odd) {
+  background: var(--in-content-box-background-odd);
+}
+
+/* Styling for the links within the table */
+#engine-urls-table a {
+  text-decoration: none;
+}
+
+#engine-urls-table a:hover {
+  text-decoration: underline;
+}

--- a/extension/content/engineUrlView.mjs
+++ b/extension/content/engineUrlView.mjs
@@ -30,48 +30,47 @@ export default class EngineUrlView extends HTMLElement {
     return fragment;
   }
 
-  createTableFragment(headers, rowHeaders, sortedUrls) {
+  createTableFragment(colHeaders, rowHeaders, sortedUrls) {
     let fragment = document.createDocumentFragment();
     let table = document.createElement("table");
-    let thead = document.createElement("thead");
-    let tbody = this.createTableBody(rowHeaders);
+    let thead = table.createTHead();
+    let tbody = table.createTBody();
 
-    Array.from(tbody.children).forEach((row, index) => {
-      let td = document.createElement("td");
-      let a = document.createElement("a");
-      a.href = sortedUrls[index];
-      a.text = sortedUrls[index];
-      td.appendChild(a);
-      row.append(td);
+    // Create header row
+    let headerRow = thead.insertRow(-1);
+    colHeaders.forEach((header) =>
+      this.createAndAppendCell(headerRow, "th", header)
+    );
+
+    // Create body rows
+    rowHeaders.forEach((header, index) => {
+      let row = tbody.insertRow(-1);
+      this.createAndAppendCell(row, "th", header);
+
+      let cell = row.insertCell(-1);
+      let url = sortedUrls[index];
+      if (url) {
+        cell.appendChild(this.createAnchor(url));
+      } else {
+        cell.textContent = "Not Specified";
+      }
     });
 
-    thead.appendChild(this.createTableRow(headers, "th"));
-    table.appendChild(thead);
-    table.appendChild(tbody);
     fragment.appendChild(table);
-
     return fragment;
   }
 
-  createTableBody(rowHeaders) {
-    let tbody = document.createElement("tbody");
-    rowHeaders.forEach((header) => {
-      let row = this.createTableRow([header], "th");
-      tbody.appendChild(row);
-    });
-
-    return tbody;
+  createAndAppendCell(row, cellType, textContent) {
+    let cell = document.createElement(cellType);
+    cell.textContent = textContent;
+    row.appendChild(cell);
   }
 
-  createTableRow(cellData, cellType) {
-    let tr = document.createElement("tr");
-    cellData.forEach((data) => {
-      let cell = document.createElement(cellType);
-      let text = document.createTextNode(data);
-      cell.appendChild(text);
-      tr.appendChild(cell);
-    });
-
-    return tr;
+  createAnchor(url) {
+    let a = document.createElement("a");
+    a.href = url;
+    a.textContent = url;
+    a.target = "_blank";
+    return a;
   }
 }

--- a/extension/content/engineUrlView.mjs
+++ b/extension/content/engineUrlView.mjs
@@ -1,0 +1,77 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+export default class EngineUrlView extends HTMLElement {
+  constructor() {
+    super();
+  }
+
+  async loadEngineUrls(config) {
+    const COL_HEADERS = [
+      "URL Type",
+      `Full URL for ${config.name} `,
+      "Method",
+      "Results",
+    ];
+    const ROW_HEADERS = ["search", "suggest", "trending"];
+
+    let urls = await browser.experiments.searchengines.getEngineUrls(config);
+    let sortedUrls = ROW_HEADERS.map((key) => urls[key]);
+
+    let fragment = this.createTableFragment(
+      COL_HEADERS,
+      ROW_HEADERS,
+      sortedUrls
+    );
+
+    this.appendChild(fragment);
+
+    return fragment;
+  }
+
+  createTableFragment(headers, rowHeaders, sortedUrls) {
+    let fragment = document.createDocumentFragment();
+    let table = document.createElement("table");
+    let thead = document.createElement("thead");
+    let tbody = this.createTableBody(rowHeaders);
+
+    Array.from(tbody.children).forEach((row, index) => {
+      let td = document.createElement("td");
+      let a = document.createElement("a");
+      a.href = sortedUrls[index];
+      a.text = sortedUrls[index];
+      td.appendChild(a);
+      row.append(td);
+    });
+
+    thead.appendChild(this.createTableRow(headers, "th"));
+    table.appendChild(thead);
+    table.appendChild(tbody);
+    fragment.appendChild(table);
+
+    return fragment;
+  }
+
+  createTableBody(rowHeaders) {
+    let tbody = document.createElement("tbody");
+    rowHeaders.forEach((header) => {
+      let row = this.createTableRow([header], "th");
+      tbody.appendChild(row);
+    });
+
+    return tbody;
+  }
+
+  createTableRow(cellData, cellType) {
+    let tr = document.createElement("tr");
+    cellData.forEach((data) => {
+      let cell = document.createElement(cellType);
+      let text = document.createTextNode(data);
+      cell.appendChild(text);
+      tr.appendChild(cell);
+    });
+
+    return tr;
+  }
+}

--- a/extension/content/engineUrlView.mjs
+++ b/extension/content/engineUrlView.mjs
@@ -11,8 +11,8 @@ export default class EngineUrlView extends HTMLElement {
     const COL_HEADERS = [
       "URL Type",
       `Full URL for ${config.name} `,
-      "Method",
-      "Results",
+      // TODO: Add Method display
+      // "Method",
     ];
     const ROW_HEADERS = ["search", "suggest", "trending"];
 
@@ -72,5 +72,13 @@ export default class EngineUrlView extends HTMLElement {
     a.textContent = url;
     a.target = "_blank";
     return a;
+  }
+
+  clear() {
+    for (let childNode of this.children) {
+      if (childNode.tagName.toLowerCase() == "table") {
+        childNode.remove();
+      }
+    }
   }
 }

--- a/extension/content/enginesView.mjs
+++ b/extension/content/enginesView.mjs
@@ -89,6 +89,8 @@ export default class EnginesView extends HTMLElement {
     }
     await this.initialize();
 
+    document.getElementById("engine-urls-table").clear();
+
     if (config) {
       if (
         !(await validateConfiguration(JSON.parse(config))) ||

--- a/extension/content/enginesView.mjs
+++ b/extension/content/enginesView.mjs
@@ -133,31 +133,29 @@ export default class EnginesView extends HTMLElement {
     Utils.addDiv(fragment, "Desktop Icon");
     for (let [i, e] of engines.entries()) {
       if (i == 0) {
-        Utils.addDiv(fragment, "1 (Application Default)", e.identifier);
+        Utils.addDiv(fragment, "1 (Application Default)", e);
       } else {
-        Utils.addDiv(fragment, i + 1, e.identifier);
+        Utils.addDiv(fragment, i + 1, e);
       }
-      Utils.addDiv(fragment, e.identifier, e.identifier);
-      Utils.addDiv(fragment, e.name, e.identifier);
+      Utils.addDiv(fragment, e.identifier, e);
+      Utils.addDiv(fragment, e.name, e);
       Utils.addDiv(
         fragment,
         "telemetrySuffix" in e
           ? `${e.identifier}-${e.telemetrySuffix}`
           : e.identifier,
-        e.identifier
+        e
       );
-      Utils.addDiv(fragment, e.partnerCode, e.identifier);
-      Utils.addDiv(fragment, e.classification, e.identifier);
-      Utils.addDiv(fragment, JSON.stringify(e.aliases), e.identifier);
+      Utils.addDiv(fragment, e.partnerCode, e);
+      Utils.addDiv(fragment, e.classification, e);
+      Utils.addDiv(fragment, JSON.stringify(e.aliases), e);
       Utils.addImage(
         fragment,
         this.#attachmentBaseUrl + this.#getIcon(e.identifier),
-        e.identifier
+        e
       );
     }
-    this.shadowRoot.getElementById("engines-table").textContent = "";
     this.shadowRoot.getElementById("engines-table").appendChild(fragment);
-
     this.shadowRoot.getElementById("private-browsing-engine").innerText =
       privateDefault ? privateDefault : "Unset";
   }

--- a/extension/content/enginesView.mjs
+++ b/extension/content/enginesView.mjs
@@ -155,7 +155,9 @@ export default class EnginesView extends HTMLElement {
         e
       );
     }
+    this.shadowRoot.getElementById("engines-table").textContent = "";
     this.shadowRoot.getElementById("engines-table").appendChild(fragment);
+
     this.shadowRoot.getElementById("private-browsing-engine").innerText =
       privateDefault ? privateDefault : "Unset";
   }

--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -31,6 +31,11 @@
               <compare-view id="compare-view"></compare-view>
             </div>
           </div>
+          <div id="engine-urls">
+            <engine-url-view id="engine-urls-table">
+              <link rel="stylesheet" href="engineUrlView.css" />
+            </engine-url-view>
+          </div>
         </div>
       </div>
     </form>
@@ -148,6 +153,9 @@
         </div>
       </fieldset>
 
+      <p id="tooltip">
+        <span> 💡 Click on an engine row to display the engine's URLs 💡 </span>
+      </p>
       <div id="engines-table"></div>
       <p id="pb-message">
         <strong>Private Browsing Application Default:</strong>

--- a/extension/content/script.mjs
+++ b/extension/content/script.mjs
@@ -97,6 +97,7 @@ async function changeTabs(event) {
   await $("#config-controller").setCompareConfigsSelected(
     $("#compare-configs").hasAttribute("selected")
   );
+  $("#engine-urls-table").clear();
 
   await setupTabs(event.target.id);
 }
@@ -125,14 +126,10 @@ async function displayUrls(e) {
 
   // When a new row is clicked, remove the last table to show the new table
   // of urls for the new row
-  for (let i = 0; i < $("#engine-urls-table").children.length; i++) {
-    let childNode = $("#engine-urls-table").children[i];
-    if (childNode.tagName.toLowerCase() == "table") {
-      childNode.remove();
-    }
-  }
+  let engineUrlsTable = $("#engine-urls-table");
+  engineUrlsTable.clear();
 
-  await $("#engine-urls-table").loadEngineUrls(e.target.data);
+  await engineUrlsTable.loadEngineUrls(e.target.data);
 }
 
 function reloadPage(event) {

--- a/extension/content/script.mjs
+++ b/extension/content/script.mjs
@@ -10,6 +10,7 @@ import CompareView from "./compareView.mjs";
 import CompareViewOld from "./compareViewOld.mjs";
 import EnginesView from "./enginesView.mjs";
 import EnginesViewOld from "./enginesViewOld.mjs";
+import EngineUrlView from "./engineUrlView.mjs";
 
 const searchengines = browser.experiments.searchengines;
 
@@ -20,6 +21,7 @@ if (!searchengines) {
 }
 
 const $ = document.querySelector.bind(document);
+let lastClickedRow = null;
 
 async function main() {
   // Always clear the local storage on load, so that we don't have old data.
@@ -43,6 +45,7 @@ async function main() {
     customElements.define("compare-view", CompareView);
     customElements.define("engines-view", EnginesView);
     customElements.define("by-engine-view", ByEngineView);
+    customElements.define("engine-url-view", EngineUrlView);
   }
 
   await initUI();
@@ -67,6 +70,10 @@ async function initUI() {
   $("#engines-view")
     .shadowRoot.getElementById("engines-table")
     .addEventListener("click", showConfig);
+
+  $("#engines-view")
+    .shadowRoot.getElementById("engines-table")
+    .addEventListener("click", displayUrls);
 
   $("#by-locales").setAttribute("selected", true);
   $("#by-locales-tab").setAttribute("selected", true);
@@ -98,11 +105,34 @@ async function showConfig(e) {
   if (e.target.tagName.toLowerCase() != "div") {
     return;
   }
-  let id = e.target.dataset.id;
+  let id = e.target.data.identifier;
   if (!id) {
     return;
   }
   $("#config-controller").moveConfigToId(id);
+}
+
+async function displayUrls(e) {
+  let clickedRow = e.target.closest("div");
+
+  // If the clicked row is the same as the last clicked row, do nothing
+  if (clickedRow === lastClickedRow) {
+    return;
+  }
+
+  // Update the reference to the last clicked row
+  lastClickedRow = clickedRow;
+
+  // When a new row is clicked, remove the last table to show the new table
+  // of urls for the new row
+  for (let i = 0; i < $("#engine-urls-table").children.length; i++) {
+    let childNode = $("#engine-urls-table").children[i];
+    if (childNode.tagName.toLowerCase() == "table") {
+      childNode.remove();
+    }
+  }
+
+  await $("#engine-urls-table").loadEngineUrls(e.target.data);
 }
 
 function reloadPage(event) {

--- a/extension/content/utils.mjs
+++ b/extension/content/utils.mjs
@@ -3,11 +3,11 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 let Utils = {
-  addDiv(element, content, dataId = "", className = "") {
+  addDiv(element, content, data = "", className = "") {
     let div = document.createElement("div");
     div.textContent = content;
-    if (dataId) {
-      div.setAttribute("data-id", dataId);
+    if (data) {
+      div.data = data;
     }
     if (className) {
       div.className = className;
@@ -15,10 +15,10 @@ let Utils = {
     element.appendChild(div);
   },
 
-  addImage(element, src, dataId = "") {
+  addImage(element, src, data = "") {
     let div = document.createElement("div");
-    if (dataId) {
-      div.setAttribute("data-id", dataId);
+    if (data) {
+      div.data = data;
     }
     if (src) {
       let image = document.createElement("img");

--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -17,11 +17,14 @@ ChromeUtils.defineESModuleGetters(this, {
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
 
 async function getEngineUrls(engineConfig) {
+  // This supports early versions of search consolidation where
+  // AppProvidedSearchEngine still required webExtension id.
+  // Example: In Bug 1901859, changes were made for Firefox ESR (search-config-v1).
   engineConfig.webExtension = { id: "cute kitten" };
 
-  // WebExtensions automatically assign a null value to optional properties,
-  // which can cause errors when retrieving the URLs. To prevent these errors,
-  // we need to remove any properties that have a null value.
+  // WebExtension APIs translation automatically assigns a null value to optional
+  // properties, which can cause errors when retrieving the URLs. To prevent
+  // these errors, we need to remove any properties that have a null value.
   for (let [key, url] of Object.entries(engineConfig.urls)) {
     if (!url) {
       delete engineConfig.urls[key];

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -2,6 +2,104 @@
   {
     "namespace": "experiments.searchengines",
     "description": "Search Engines",
+    "types": [
+      {
+        "id": "EngineUrl",
+        "type": "object",
+        "properties": {
+          "base": {
+            "title": "Base",
+            "description": "The PrePath and FilePath of the URL. May include variables for engines which have a variable FilePath, e.g. {searchTerm} for when a search term is within the path of the url.",
+            "type": "string"
+          },
+          "method": {
+            "title": "Method",
+            "description": "The HTTP method to use to send the request. If not specified, defaults to GET.",
+            "type": "string",
+            "pattern": "^(GET|POST)$",
+            "enum": ["GET", "POST"],
+            "optional": true
+          },
+          "params": {
+            "title": "Parameters",
+            "description": "The parameters for this URL.",
+            "type": "array",
+            "optional": true,
+            "items": {
+              "type": "object",
+              "title": "Parameter",
+              "properties": {
+                "name": {
+                  "title": "Name",
+                  "description": "The parameter name",
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9-_]*$"
+                },
+                "value": {
+                  "title": "Value",
+                  "description": "The parameter value, this may be a static value, or additionally contain a parameter replacement, e.g. {inputEncoding}. For the partner code parameter, this field should be {partnerCode}.",
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9-_{}]*$",
+                  "optional": true
+                },
+                "experimentConfig": {
+                  "title": "Experiment Configuration",
+                  "description": "The value for the parameter will be derived from the equivalent experiment configuration value. If not experiment is present, this parameter will not be included in the final url.",
+                  "type": "string",
+                  "pattern": "^[a-zA-Z0-9-_]*$",
+                  "optional": true
+                },
+                "searchAccessPoint": {
+                  "title": "Search Access Point",
+                  "description": "A parameter whose value depends on the access point where the search was initiated.",
+                  "type": "object",
+                  "optional": true,
+                  "properties": {
+                    "searchbar": {
+                      "title": "Name",
+                      "description": "The value for the parameter when searched from the search bar.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9-_]*$"
+                    },
+                    "addressbar": {
+                      "title": "Name",
+                      "description": "The value for the parameter when searched from the address bar.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9-_]*$"
+                    },
+                    "contextmenu": {
+                      "title": "Name",
+                      "description": "The value for the parameter when searched from the context menu.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9-_]*$"
+                    },
+                    "homepage": {
+                      "title": "Name",
+                      "description": "The value for the parameter when searched from the homepage.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9-_]*$"
+                    },
+                    "newtab": {
+                      "title": "Name",
+                      "description": "The value for the parameter when searched from the new tab page.",
+                      "type": "string",
+                      "pattern": "^[a-zA-Z0-9-_]*$"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "searchTermParamName": {
+            "title": "Search Term Parameter Name",
+            "description": "The name of the query parameter for the search term. Automatically appended to the end of the query. This may be skipped if `{searchTerm}` is included in the base.",
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9-_]*$",
+            "optional": true
+          }
+        }
+      }
+    ],
     "functions": [
       {
         "name": "getCurrentLocale",
@@ -68,6 +166,102 @@
               "appName": {
                 "type": "string",
                 "description": "The application's name"
+              }
+            }
+          }
+        ]
+      },
+      {
+        "name": "getEngineUrls",
+        "type": "function",
+        "description": "Returns an array of search, suggestion, and trending urls.",
+        "async": true,
+        "parameters": [
+          {
+            "type": "object",
+            "name": "engineConfig",
+            "properties": {
+            "identifier": {
+              "title": "Identifier",
+              "description": "The identifier of the search engine. This is used as an internal identifier, e.g. for saving the user's settings for the engine. It is also used to form the base telemetry id and may be extended by telemetrySuffix.",
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9-_]*$"
+            },
+            "notes": {
+               "title": "Notes",
+               "description": "A short notes section used to potentially aid identification of this section for humans. Not intended for to be read by the application.",
+               "type": "string",
+               "pattern": "^[a-zA-Z0-9-_.() ]*$",
+               "optional": true
+             },
+             "telemetrySuffix": {
+               "title": "Telemetry Suffix",
+               "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`. There should always be a suffix supplied if the partner code is different for a reason other than being on a different platform.",
+               "type": "string",
+               "pattern": "^[a-zA-Z0-9-]*$",
+               "optional": true
+             },
+            "aliases": {
+              "title": "Aliases",
+              "description": "An array of aliases that the user can use to search with this engine. The aliases will be prefix by '@' on desktop and potentially other platforms.",
+              "type": "array",
+              "items": {
+                "type": "string",
+                "pattern": "^[a-z\\xa1-\\uffff]*$"
+              },
+              "uniqueItems": true,
+              "optional": true
+            },
+            "charset": {
+              "title": "Character Set",
+              "description": "The character set this engine uses for queries. Defaults to 'UTF=8' if not set.",
+              "type": "string",
+              "pattern": "^[a-zA-Z0-9-]*$",
+              "optional": true
+            },
+            "classification": {
+              "title": "Classification",
+              "description": "The classification of search engine according to the main search types (e.g. general, shopping, travel, dictionary). Currently, only marking as a general search engine is supported.",
+              "type": "string",
+              "enum": ["general", "unknown"],
+              "optional": true
+            },
+            "name": {
+              "title": "Name",
+              "description": "The user visible name for the search engine.",
+              "type": "string",
+              "maxLength": 100
+            },
+            "partnerCode": {
+            "title": "Partner Code",
+             "description": "The partner code for the engine or variant. This will be inserted into parameters which include '{partnerCode}'",
+             "type": "string",
+             "pattern": "^[a-zA-Z0-9-_]*$",
+             "optional": true
+            },
+            "urls": {
+              "title": "URLs",
+              "description": "The URLs associated with the search engine.",
+              "type": "object",
+              "properties": {
+                "search": {
+                  "title": "Search URL",
+                  "description": "The URL to use for searches",
+                  "$ref": "EngineUrl"
+                },
+                "suggestions": {
+                  "title": "Suggestions URL",
+                  "description": "The URL to use for suggestions",
+                  "$ref": "EngineUrl",
+                  "optional": true
+                },
+                "trending": {
+                  "title": "Trending Suggestions URL",
+                  "description": "The URL to use for tending suggestions",
+                  "$ref": "EngineUrl",
+                  "optional": true
+                  }
+                }
               }
             }
           }

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -181,85 +181,85 @@
             "type": "object",
             "name": "engineConfig",
             "properties": {
-            "identifier": {
-              "title": "Identifier",
-              "description": "The identifier of the search engine. This is used as an internal identifier, e.g. for saving the user's settings for the engine. It is also used to form the base telemetry id and may be extended by telemetrySuffix.",
-              "type": "string",
-              "pattern": "^[a-zA-Z0-9-_]*$"
-            },
-            "notes": {
-               "title": "Notes",
-               "description": "A short notes section used to potentially aid identification of this section for humans. Not intended for to be read by the application.",
-               "type": "string",
-               "pattern": "^[a-zA-Z0-9-_.() ]*$",
-               "optional": true
-             },
-             "telemetrySuffix": {
-               "title": "Telemetry Suffix",
-               "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`. There should always be a suffix supplied if the partner code is different for a reason other than being on a different platform.",
-               "type": "string",
-               "pattern": "^[a-zA-Z0-9-]*$",
-               "optional": true
-             },
-            "aliases": {
-              "title": "Aliases",
-              "description": "An array of aliases that the user can use to search with this engine. The aliases will be prefix by '@' on desktop and potentially other platforms.",
-              "type": "array",
-              "items": {
+              "identifier": {
+                "title": "Identifier",
+                "description": "The identifier of the search engine. This is used as an internal identifier, e.g. for saving the user's settings for the engine. It is also used to form the base telemetry id and may be extended by telemetrySuffix.",
                 "type": "string",
-                "pattern": "^[a-z\\xa1-\\uffff]*$"
+                "pattern": "^[a-zA-Z0-9-_]*$"
               },
-              "uniqueItems": true,
-              "optional": true
-            },
-            "charset": {
-              "title": "Character Set",
-              "description": "The character set this engine uses for queries. Defaults to 'UTF=8' if not set.",
-              "type": "string",
-              "pattern": "^[a-zA-Z0-9-]*$",
-              "optional": true
-            },
-            "classification": {
-              "title": "Classification",
-              "description": "The classification of search engine according to the main search types (e.g. general, shopping, travel, dictionary). Currently, only marking as a general search engine is supported.",
-              "type": "string",
-              "enum": ["general", "unknown"],
-              "optional": true
-            },
-            "name": {
-              "title": "Name",
-              "description": "The user visible name for the search engine.",
-              "type": "string",
-              "maxLength": 100
-            },
-            "partnerCode": {
-            "title": "Partner Code",
-             "description": "The partner code for the engine or variant. This will be inserted into parameters which include '{partnerCode}'",
-             "type": "string",
-             "pattern": "^[a-zA-Z0-9-_]*$",
-             "optional": true
-            },
-            "urls": {
-              "title": "URLs",
-              "description": "The URLs associated with the search engine.",
-              "type": "object",
-              "properties": {
-                "search": {
-                  "title": "Search URL",
-                  "description": "The URL to use for searches",
-                  "$ref": "EngineUrl"
+              "notes": {
+                "title": "Notes",
+                "description": "A short notes section used to potentially aid identification of this section for humans. Not intended for to be read by the application.",
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-_.() ]*$",
+                "optional": true
+              },
+              "telemetrySuffix": {
+                "title": "Telemetry Suffix",
+                "description": "Suffix that is appended to the search engine identifier following a dash, i.e. `<identifier>-<suffix>`. There should always be a suffix supplied if the partner code is different for a reason other than being on a different platform.",
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-]*$",
+                "optional": true
+              },
+              "aliases": {
+                "title": "Aliases",
+                "description": "An array of aliases that the user can use to search with this engine. The aliases will be prefix by '@' on desktop and potentially other platforms.",
+                "type": "array",
+                "items": {
+                  "type": "string",
+                  "pattern": "^[a-z\\xa1-\\uffff]*$"
                 },
-                "suggestions": {
-                  "title": "Suggestions URL",
-                  "description": "The URL to use for suggestions",
-                  "$ref": "EngineUrl",
-                  "optional": true
-                },
-                "trending": {
-                  "title": "Trending Suggestions URL",
-                  "description": "The URL to use for tending suggestions",
-                  "$ref": "EngineUrl",
-                  "optional": true
+                "uniqueItems": true,
+                "optional": true
+              },
+              "charset": {
+                "title": "Character Set",
+                "description": "The character set this engine uses for queries. Defaults to 'UTF=8' if not set.",
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-]*$",
+                "optional": true
+              },
+              "classification": {
+                "title": "Classification",
+                "description": "The classification of search engine according to the main search types (e.g. general, shopping, travel, dictionary). Currently, only marking as a general search engine is supported.",
+                "type": "string",
+                "enum": ["general", "unknown"],
+                "optional": true
+              },
+              "name": {
+                "title": "Name",
+                "description": "The user visible name for the search engine.",
+                "type": "string",
+                "maxLength": 100
+              },
+              "partnerCode": {
+                "title": "Partner Code",
+                "description": "The partner code for the engine or variant. This will be inserted into parameters which include '{partnerCode}'",
+                "type": "string",
+                "pattern": "^[a-zA-Z0-9-_]*$",
+                "optional": true
+              },
+              "urls": {
+                "title": "URLs",
+                "description": "The URLs associated with the search engine.",
+                "type": "object",
+                "properties": {
+                  "search": {
+                    "title": "Search URL",
+                    "description": "The URL to use for searches",
+                    "$ref": "EngineUrl"
+                  },
+                  "suggestions": {
+                    "title": "Suggestions URL",
+                    "description": "The URL to use for suggestions",
+                    "$ref": "EngineUrl",
+                    "optional": true
+                  },
+                  "trending": {
+                    "title": "Trending Suggestions URL",
+                    "description": "The URL to use for tending suggestions",
+                    "$ref": "EngineUrl",
+                    "optional": true
                   }
                 }
               }


### PR DESCRIPTION
Method and results not added in the tablet yet. We discussed adding those in another patch. 

**Light Mode:**
<img width="1267" alt="Screenshot 2024-06-28 at 3 54 42 PM" src="https://github.com/mozilla-extensions/searchengine-devtools/assets/23747390/1d2c1188-d727-4443-a720-87b9ce78b5f9">

**Dark Mode:** 
<img width="1265" alt="Screenshot 2024-06-28 at 3 54 11 PM" src="https://github.com/mozilla-extensions/searchengine-devtools/assets/23747390/b270044f-d095-40d9-927c-8c60dbe45841">
