### PR TITLE
fix: Handle a URL definition not having a params field.

### DIFF
--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -38,10 +38,12 @@ async function getEngineUrls(engineConfig) {
       continue;
     }
 
-    for (let property of ["experimentConfig", "searchAccessPoint", "value"]) {
-      for (let param of url.params) {
-        if (param[property] === null) {
-          delete param[property];
+    if (url.params) {
+      for (let property of ["experimentConfig", "searchAccessPoint", "value"]) {
+        for (let param of url.params) {
+          if (param[property] === null) {
+            delete param[property];
+          }
         }
       }
     }


### PR DESCRIPTION
Some records in the search configuration have no params field, this upsets the code that tries to delete the nulls, as `url.params` is null and can't be iterated over.