### PR TITLE
fix: Remove flicker when selecting different engines for displaying their URLs.

### DIFF
--- a/extension/content/engineUrlView.css
+++ b/extension/content/engineUrlView.css
@@ -1,11 +1,17 @@
 /* Set the general styling for the table */
 #engine-urls-table table {
+  table-layout: fixed;
   width: 100%;
   border-collapse: collapse;
   margin: 20px 0;
   font-size: 1rem;
   text-align: center;
   border: 1px solid lightgray;
+}
+
+#engine-urls-table th:first-child,
+#engine-urls-table td:first-child {
+  width: max-content;
 }
 
 /* Style for the table headers */

--- a/extension/content/script.mjs
+++ b/extension/content/script.mjs
@@ -127,7 +127,6 @@ async function displayUrls(e) {
   // When a new row is clicked, remove the last table to show the new table
   // of urls for the new row
   let engineUrlsTable = $("#engine-urls-table");
-  engineUrlsTable.clear();
 
   await engineUrlsTable.loadEngineUrls(e.target.data);
 }


### PR DESCRIPTION
This avoids clearing the table on every reload and instead updates the existing table if there is one.