### PR TITLE
fix: Fix broken empty image configuration used for manual configurations.

### DIFF
--- a/extension/content/configController.mjs
+++ b/extension/content/configController.mjs
@@ -125,7 +125,7 @@ export default class ConfigController extends HTMLElement {
     const buttonValue =
       this.shadowRoot.getElementById(`primary-config`).selected;
     if (buttonValue == "local-text") {
-      return "{}";
+      return `{"data":[]}`;
     }
     return fetchCached(await this.#getIconsUrl(buttonValue));
   }


### PR DESCRIPTION
I noticed that simply selecting "manual" in the latest searchengine-devtools is broken.