### PR TITLE
Bug 1928347 - Add searchForm URL display to searchengine-devtools

### DIFF
--- a/extension/content/engineUrlView.css
+++ b/extension/content/engineUrlView.css
@@ -1,12 +1,17 @@
 /* Set the general styling for the table */
 #engine-urls-table table {
-  table-layout: fixed;
+  table-layout: auto;
   width: 100%;
   border-collapse: collapse;
   margin: 20px 0;
   font-size: 1rem;
   text-align: center;
   border: 1px solid lightgray;
+}
+
+#engine-urls-table th,
+#engine-urls-table td {
+  width: 100%;
 }
 
 #engine-urls-table th:first-child,

--- a/extension/content/engineUrlView.mjs
+++ b/extension/content/engineUrlView.mjs
@@ -13,7 +13,7 @@ export default class EngineUrlView extends HTMLElement {
 
   #suggestionsTable = document.getElementById("engine-suggestions-table");
 
-  #ROW_HEADERS = ["search", "suggest", "trending"];
+  #ROW_HEADERS = ["search", "suggest", "trending", "searchForm"];
 
   constructor() {
     super();

--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -116,6 +116,7 @@ async function getEngines(options) {
         search: getSubmission("text/html"),
         suggest: getSubmission("application/x-suggestions+json"),
         trending: getSubmission("application/x-trending+json"),
+        searchForm: appProvidedEngine.searchForm,
       },
     };
   });


### PR DESCRIPTION
In [bug 1916505](https://bugzilla.mozilla.org/show_bug.cgi?id=1916505) we are adding searchForm support to the search configuration. We should add the display of the search form to the list of URLs that are displayed for engines when they are clicked on.