### PR TITLE
fix: Fix the Locale/region by engine view.

### DIFF
--- a/extension/content/byEngineView.mjs
+++ b/extension/content/byEngineView.mjs
@@ -190,7 +190,10 @@ export default class ByEngineView extends HTMLElement {
     return JSON.stringify({
       data: config.data.filter((item) => {
         return (
-          item.recordType == "engine" && item.identifier.startsWith(engineId)
+          (item.recordType == "engine" &&
+            item.identifier.startsWith(engineId)) ||
+          item.recordType == "defaultEngines" ||
+          item.recordType == "engineOrders"
         );
       }),
     });

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -165,7 +165,8 @@
               },
               "channel": {
                 "type": "string",
-                "description": "The user's update channel"
+                "description": "The user's update channel",
+                "optional": true
               },
               "appName": {
                 "type": "string",
@@ -173,7 +174,8 @@
               },
               "version": {
                 "type": "string",
-                "description": "The application's version"
+                "description": "The application's version",
+                "optional": true
               }
             }
           }


### PR DESCRIPTION
The current view isn't working, as it sees the configuration as missing records (default engines & engine orders), and then doesn't handle returning no engines.