### PR TITLE
Fix compatibility issues

### DIFF
--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -4,16 +4,50 @@
 
 /* global ExtensionAPI, XPCOMUtils, Services, Cc, Ci */
 
-ChromeUtils.defineESModuleGetters(this, {
-  FilterExpressions:
-    "resource://gre/modules/components-utils/FilterExpressions.sys.mjs",
-  SearchEngineSelector: "resource://gre/modules/SearchEngineSelector.sys.mjs",
-  SearchSuggestionController:
-    "resource://gre/modules/SearchSuggestionController.sys.mjs",
-  SearchUtils: "resource://gre/modules/SearchUtils.sys.mjs",
-  AppProvidedSearchEngine:
-    "resource://gre/modules/AppProvidedSearchEngine.sys.mjs",
-});
+let FilterExpressions;
+let SearchEngineSelector;
+let SearchSuggestionController;
+let SearchUtils;
+let AppProvidedSearchEngine;
+
+// Support pre and post moz-src URLs. These are in two separate try/catch
+// statements, as we expect them to land at separate times.
+try {
+  ({ FilterExpressions } = ChromeUtils.importESModule(
+    "resource://gre/modules/components-utils/FilterExpressions.sys.mjs"
+  ));
+} catch {
+  ({ FilterExpressions } = ChromeUtils.importESModule(
+    "moz-src:///toolkit/components/utils/FilterExpressions.sys.mjs"
+  ));
+}
+try {
+  ({ SearchEngineSelector } = ChromeUtils.importESModule(
+    "resource://gre/modules/SearchEngineSelector.sys.mjs"
+  ));
+  ({ SearchSuggestionController } = ChromeUtils.importESModule(
+    "resource://gre/modules/SearchSuggestionController.sys.mjs"
+  ));
+  ({ SearchUtils } = ChromeUtils.importESModule(
+    "resource://gre/modules/SearchUtils.sys.mjs"
+  ));
+  ({ AppProvidedSearchEngine } = ChromeUtils.importESModule(
+    "resource://gre/modules/AppProvidedSearchEngine.sys.mjs"
+  ));
+} catch {
+  ({ SearchEngineSelector } = ChromeUtils.importESModule(
+    "moz-src:///toolkit/components/search/SearchEngineSelector.sys.mjs"
+  ));
+  ({ SearchSuggestionController } = ChromeUtils.importESModule(
+    "moz-src:///toolkit/components/search/SearchSuggestionController.sys.mjs"
+  ));
+  ({ SearchUtils } = ChromeUtils.importESModule(
+    "moz-src:///toolkit/components/search/SearchUtils.sys.mjs"
+  ));
+  ({ AppProvidedSearchEngine } = ChromeUtils.importESModule(
+    "moz-src:///toolkit/components/search/AppProvidedSearchEngine.sys.mjs"
+  ));
+}
 
 // eslint-disable-next-line mozilla/reject-importGlobalProperties
 XPCOMUtils.defineLazyGlobalGetters(this, ["fetch"]);
@@ -146,9 +180,7 @@ async function getSuggestions(url, suggestionsType) {
     false,
     {
       getSubmission() {
-        return {
-          uri: Services.io.newURI(url),
-        };
+        return { uri: Services.io.newURI(url) };
       },
       supportsResponseType() {
         return true;

--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -73,16 +73,13 @@ async function getCurrentLocale() {
 async function getEngines(options) {
   let engineSelector = new SearchEngineSelector();
 
-  engineSelector.getEngineConfiguration = async () => {
-    let config = JSON.parse(options.configData).data;
-    engineSelector._configuration = config;
+  engineSelector._onConfigurationUpdated({
+    data: { current: JSON.parse(options.configData).data },
+  });
 
-    engineSelector._configurationOverrides = JSON.parse(
-      options.configOverridesData
-    ).data;
-
-    return config;
-  };
+  engineSelector._onConfigurationOverridesUpdated({
+    data: { current: JSON.parse(options.configOverridesData).data },
+  });
 
   // Due to the way the extension APIs work, if these values are not specified,
   // then they are given the `null` value. This in turn defeats the default

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "browser_specific_settings": {
@@ -11,9 +11,7 @@
       "update_url": "https://raw.githubusercontent.com/mozilla-extensions/searchengine-devtools/master/update.json"
     }
   },
-  "background": {
-    "scripts": ["background.js"]
-  },
+  "background": { "scripts": ["background.js"] },
   "browser_action": {
     "default_title": "SearchEngines Devtools",
     "browser_style": true
@@ -24,9 +22,7 @@
     "https://firefox.settings.services.allizom.org/*",
     "https://hg.mozilla.org/"
   ],
-  "icons": {
-    "550": "icon.png"
-  },
+  "icons": { "550": "icon.png" },
   "experiment_apis": {
     "searchengines": {
       "schema": "experiments/searchengines/schema.json",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "webExt": {


### PR DESCRIPTION
With switching to the Rust based engine selector, we need to set the configuration slightly differently for searchengine-devtools.

Additionally, in preparation for the moz-src:// url protocol, I want to add fallbacks so that we can handle the before or after state