### PR TITLE
Fix records without a filter_expression.

### DIFF
--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -203,6 +203,9 @@ async function jexlFilterMatches(
   applicationId,
   applicationVersion
 ) {
+  if (!filterExpression) {
+    return true;
+  }
   return !!(await FilterExpressions.eval(filterExpression, {
     env: { appinfo: { ID: applicationId }, version: applicationVersion },
   }));

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -202,7 +202,8 @@
           {
             "name": "filterExpression",
             "type": "string",
-            "description": "The filter expression to check"
+            "description": "The filter expression to check",
+            "optional": true
           },
           {
             "name": "applicationId",

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "browser_specific_settings": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "webExt": {


### PR DESCRIPTION
Records without filter expressions cause the search engine devtools to crash. This should fix it.

In the browser, its done in a similar way: https://searchfox.org/mozilla-central/rev/5bea6ede57be43d450ecc24af7a535288c9a9f7d/services/settings/remote-settings.sys.mjs#84-86