### PR TITLE
Improve Icon handling & Aliases Readability

### DIFF
--- a/extension/content/enginesView.css
+++ b/extension/content/enginesView.css
@@ -19,7 +19,7 @@
 
 #engines-table {
   display: grid;
-  grid-template-columns: repeat(9, max-content);
+  grid-template-columns: repeat(8, max-content);
   padding-top: 1em;
   margin: 0 auto;
   width: max-content;
@@ -29,19 +29,19 @@
   padding: 0.3em 1em;
 }
 
-#engines-table > div:nth-child(-n + 9) {
+#engines-table > div:nth-child(-n + 8) {
   font-weight: bold;
   text-align: center;
   padding-bottom: 0.5em;
 }
 
-#engines-table > div:nth-child(n + 9) {
+#engines-table > div:nth-child(n + 8) {
   opacity: 0.8;
   cursor: pointer;
 }
 
-#engines-table > div:nth-child(9n + 17),
-#engines-table > div:nth-child(9n + 18) {
+#engines-table > div:nth-child(8n + 15),
+#engines-table > div:nth-child(8n + 16) {
   opacity: 1;
   text-align: center;
 }
@@ -60,19 +60,18 @@
   height: 24px;
 }
 
-#engines-table > div:nth-child(n + 9):hover {
+#engines-table > div:nth-child(n + 8):hover {
   opacity: 1;
 }
 
-#engines-table > div:nth-child(9n + 10):nth-child(18n + 10),
-#engines-table > div:nth-child(9n + 11):nth-child(18n + 11),
-#engines-table > div:nth-child(9n + 12):nth-child(18n + 12),
-#engines-table > div:nth-child(9n + 13):nth-child(18n + 13),
-#engines-table > div:nth-child(9n + 14):nth-child(18n + 14),
-#engines-table > div:nth-child(9n + 15):nth-child(18n + 15),
-#engines-table > div:nth-child(9n + 16):nth-child(18n + 16),
-#engines-table > div:nth-child(9n + 17):nth-child(18n + 17),
-#engines-table > div:nth-child(9n + 18):nth-child(18n + 18) {
+#engines-table > div:nth-child(8n + 9):nth-child(16n + 9),
+#engines-table > div:nth-child(8n + 10):nth-child(16n + 10),
+#engines-table > div:nth-child(8n + 11):nth-child(16n + 11),
+#engines-table > div:nth-child(8n + 12):nth-child(16n + 12),
+#engines-table > div:nth-child(8n + 13):nth-child(16n + 13),
+#engines-table > div:nth-child(8n + 14):nth-child(16n + 14),
+#engines-table > div:nth-child(8n + 15):nth-child(16n + 15),
+#engines-table > div:nth-child(8n + 16):nth-child(16n + 16) {
   background: var(--in-content-box-background-odd);
 }
 

--- a/extension/content/enginesView.mjs
+++ b/extension/content/enginesView.mjs
@@ -108,7 +108,8 @@ export default class EnginesView extends HTMLElement {
       }
       this.#config = config;
       this.#configOverrides = configOverrides;
-      this.#iconConfig = JSON.parse(iconConfig);
+      this.#iconConfig = await Utils.filterIconConfig(JSON.parse(iconConfig));
+
       this.#attachmentBaseUrl = attachmentBaseUrl;
     }
     if (!this.#config) {
@@ -154,7 +155,7 @@ export default class EnginesView extends HTMLElement {
       Utils.addImage(
         fragment,
         this.#attachmentBaseUrl +
-          (await Utils.getIcon(this.#iconConfig, e.identifier, 16)),
+          Utils.getIcon(this.#iconConfig, e.identifier, 16),
         16,
         e
       );

--- a/extension/content/enginesView.mjs
+++ b/extension/content/enginesView.mjs
@@ -151,7 +151,7 @@ export default class EnginesView extends HTMLElement {
       Utils.addDiv(fragment, e.telemetryId, e);
       Utils.addDiv(fragment, e.partnerCode, e);
       Utils.addDiv(fragment, e.classification, e);
-      Utils.addDiv(fragment, JSON.stringify(e.aliases), e);
+      Utils.addDiv(fragment, e.aliases.join(", "), e);
       Utils.addImage(
         fragment,
         this.#attachmentBaseUrl +

--- a/extension/content/enginesView.mjs
+++ b/extension/content/enginesView.mjs
@@ -138,8 +138,7 @@ export default class EnginesView extends HTMLElement {
     Utils.addDiv(fragment, "Partner Code");
     Utils.addDiv(fragment, "Classification");
     Utils.addDiv(fragment, "Aliases");
-    Utils.addDiv(fragment, "Desktop Icon (16)");
-    Utils.addDiv(fragment, "Desktop Icon (24)");
+    Utils.addDiv(fragment, "Desktop Icon");
     for (let [i, e] of engines.entries()) {
       if (i == 0) {
         Utils.addDiv(fragment, "1 (Application Default)", e);
@@ -152,25 +151,13 @@ export default class EnginesView extends HTMLElement {
       Utils.addDiv(fragment, e.partnerCode, e);
       Utils.addDiv(fragment, e.classification, e);
       Utils.addDiv(fragment, JSON.stringify(e.aliases), e);
-      // We should always have a 16x16.
       Utils.addImage(
         fragment,
-        this.#attachmentBaseUrl + (await this.#getIcon(e.identifier, 16)),
+        this.#attachmentBaseUrl +
+          (await Utils.getIcon(this.#iconConfig, e.identifier, 16)),
         16,
         e
       );
-      // 24x24 is newer so may not exist.
-      let icon24 = await this.#getIcon(e.identifier, 24);
-      if (icon24) {
-        Utils.addImage(
-          fragment,
-          this.#attachmentBaseUrl + icon24,
-          24,
-          e.identifier
-        );
-      } else {
-        Utils.addDiv(fragment, "", e.identifier);
-      }
     }
     this.shadowRoot.getElementById("engines-table").textContent = "";
     this.shadowRoot.getElementById("engines-table").appendChild(fragment);
@@ -197,39 +184,5 @@ export default class EnginesView extends HTMLElement {
     );
     this.shadowRoot.getElementById("region-select").value =
       await browser.experiments.searchengines.getCurrentRegion();
-  }
-
-  /**
-   * Finds an icon in the remote settings records, according to the required
-   * size and returns the location.
-   *
-   * @param {string} engineIdentifier
-   *   The engine identifier.
-   * @param {number} iconSize
-   *   The requested size of the icon.
-   * @returns {string}
-   *   The location of the icon on the remote settings server.
-   */
-  async #getIcon(engineIdentifier, iconSize) {
-    let browserInfo = await browser.runtime.getBrowserInfo();
-    for (let record of this.#iconConfig?.data ?? []) {
-      if (
-        record.imageSize == iconSize &&
-        (await browser.experiments.searchengines.jexlFilterMatches(
-          record.filter_expression,
-          "{ec8030f7-c20a-464f-9b0e-13a3a9e97384}",
-          browserInfo.version
-        )) &&
-        record.engineIdentifiers.some((i) => {
-          if (i.endsWith("*")) {
-            return engineIdentifier.startsWith(i.slice(0, -1));
-          }
-          return engineIdentifier == i;
-        })
-      ) {
-        return record.attachment.location;
-      }
-    }
-    return null;
   }
 }

--- a/extension/content/utils.mjs
+++ b/extension/content/utils.mjs
@@ -2,7 +2,13 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-let Utils = {
+class _Utils {
+  /**
+   * @type {string}
+   *   The current browser platform.
+   */
+  #platform = null;
+
   addDiv(element, content, data = "", className = "") {
     let div = document.createElement("div");
     div.textContent = content;
@@ -13,7 +19,7 @@ let Utils = {
       div.className = className;
     }
     element.appendChild(div);
-  },
+  }
 
   addImage(element, src, size, data = "") {
     let div = document.createElement("div");
@@ -27,7 +33,7 @@ let Utils = {
       div.appendChild(image);
     }
     element.appendChild(div);
-  },
+  }
 
   insertOptionList(field, list) {
     let fragment = document.createDocumentFragment();
@@ -37,19 +43,56 @@ let Utils = {
       fragment.appendChild(option);
     }
     field.appendChild(fragment);
-  },
+  }
 
   removeAllChildren(element) {
     while (element.firstChild) {
       element.firstChild.remove();
     }
-  },
+  }
 
   calculateTelemetryId(engineData) {
     return "telemetrySuffix" in engineData
       ? `${engineData.identifier}-${engineData.telemetrySuffix}`
       : engineData.identifier;
-  },
-};
+  }
 
+  /**
+   * Finds an icon in the remote settings records, according to the required
+   * size and returns the location.
+   *
+   * @param {string} engineIdentifier
+   *   The engine identifier.
+   * @param {number} iconSize
+   *   The requested size of the icon.
+   * @returns {string}
+   *   The location of the icon on the remote settings server.
+   */
+  async getIcon(iconConfig, engineIdentifier, iconSize) {
+    if (!this.#platform) {
+      this.#platform = (await browser.runtime.getPlatformInfo()).os;
+    }
+    for (let record of iconConfig?.data ?? []) {
+      if (
+        (!iconSize || record.imageSize == iconSize) &&
+        (!record.filter_expression ||
+          (await browser.experiments.searchengines.jexlFilterMatches(
+            record.filter_expression,
+            this.#platform
+          ))) &&
+        record.engineIdentifiers.some((i) => {
+          if (i.endsWith("*")) {
+            return engineIdentifier.startsWith(i.slice(0, -1));
+          }
+          return engineIdentifier == i;
+        })
+      ) {
+        return record.attachment.location;
+      }
+    }
+    return null;
+  }
+}
+
+const Utils = new _Utils();
 export default Utils;

--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -198,16 +198,14 @@ async function getSuggestions(url, suggestionsType) {
   return { suggestions: results.remote.map((r) => r.value), error };
 }
 
-async function jexlFilterMatches(
-  filterExpression,
-  applicationId,
-  applicationVersion
-) {
+async function jexlFilterMatches(filterExpression, applicationOS) {
   if (!filterExpression) {
     return true;
   }
   return !!(await FilterExpressions.eval(filterExpression, {
-    env: { appinfo: { ID: applicationId }, version: applicationVersion },
+    env: {
+      appinfo: { OS: applicationOS },
+    },
   }));
 }
 

--- a/extension/experiments/searchengines/schema.json
+++ b/extension/experiments/searchengines/schema.json
@@ -206,14 +206,9 @@
             "optional": true
           },
           {
-            "name": "applicationId",
+            "name": "applicationOS",
             "type": "string",
-            "description": "The application id to match against"
-          },
-          {
-            "name": "applicationVersion",
-            "type": "string",
-            "description": "The application version to match against"
+            "description": "The application OS to match against"
           }
         ]
       }


### PR DESCRIPTION
This changes the icon handling to only filter by OS, since that's all we're using now. Additionally, move the getIcon function into Utils, for easier use later.

It also updates the icon display to only have one column, since we're only aiming for one size per platform.

We also add pre-filtering to the icon records, to avoid running JEXL on every record every time we load an icon.

Finally, we simplify the aliases column into just a comma separated string, rather than using a stringified array.