### PR TITLE
fix: Stop using desktop's ordering function for search engines.

### DIFF
--- a/extension/experiments/searchengines/api.js
+++ b/extension/experiments/searchengines/api.js
@@ -7,7 +7,6 @@
 let FilterExpressions;
 let SearchEngineSelector;
 let SearchSuggestionController;
-let SearchUtils;
 let AppProvidedSearchEngine;
 
 // Support pre and post moz-src URLs. These are in two separate try/catch
@@ -28,9 +27,6 @@ try {
   ({ SearchSuggestionController } = ChromeUtils.importESModule(
     "resource://gre/modules/SearchSuggestionController.sys.mjs"
   ));
-  ({ SearchUtils } = ChromeUtils.importESModule(
-    "resource://gre/modules/SearchUtils.sys.mjs"
-  ));
   ({ AppProvidedSearchEngine } = ChromeUtils.importESModule(
     "resource://gre/modules/AppProvidedSearchEngine.sys.mjs"
   ));
@@ -40,9 +36,6 @@ try {
   ));
   ({ SearchSuggestionController } = ChromeUtils.importESModule(
     "moz-src:///toolkit/components/search/SearchSuggestionController.sys.mjs"
-  ));
-  ({ SearchUtils } = ChromeUtils.importESModule(
-    "moz-src:///toolkit/components/search/SearchUtils.sys.mjs"
   ));
   ({ AppProvidedSearchEngine } = ChromeUtils.importESModule(
     "moz-src:///toolkit/components/search/AppProvidedSearchEngine.sys.mjs"
@@ -106,12 +99,6 @@ async function getEngines(options) {
     }
     throw ex;
   }
-
-  result.engines = SearchUtils.sortEnginesByDefaults({
-    engines: result.engines,
-    appDefaultEngine: result.engines[0],
-    locale: options.locale,
-  });
 
   result.engines = result.engines.map((engine) => {
     let appProvidedEngine = new AppProvidedSearchEngine({ config: engine });

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "webExt": {


### PR DESCRIPTION
Since the selector can provide the ordering, we should rely on that instead so that we can better reflect the orders that Android & iOS have.