### PR TITLE
Remove now unnecessary eslint-env comments.

### DIFF
--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 module.exports = {
   endOfLine: "lf",
   printWidth: 80,

--- a/schemas/generateValidator.js
+++ b/schemas/generateValidator.js
@@ -2,8 +2,6 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
-/* eslint-env node */
-
 const fs = require("fs");
 const path = require("path");
 const Ajv = require("ajv");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,3 @@
-/* eslint-env node */
-
 const path = require("path");
 
 module.exports = {


### PR DESCRIPTION
Eslint v9 made these obsolete, and is now warning about them ahead of them raising errors in v10. We can safely remove them as there's already a section in eslint.config.mjs that covers setting the environment for these files.