### PR TITLE
Display images from all platforms, and allow linking to pdf based images for iOS

### DIFF
--- a/extension/content/allEnginesView.mjs
+++ b/extension/content/allEnginesView.mjs
@@ -68,6 +68,10 @@ export default class AllEnginesView extends HTMLElement {
         // Icon
         let imageCell = row.insertCell();
         imageCell.className = "icon";
+        imageCell = row.insertCell();
+        imageCell.className = "icon";
+        imageCell = row.insertCell();
+        imageCell.className = "icon";
         // Identifier
         row.insertCell();
         // Display Name
@@ -83,17 +87,26 @@ export default class AllEnginesView extends HTMLElement {
         row = rows[currentRowIndex];
       }
 
-      Utils.addOrUpdateImage(
+      Utils.addOrUpdateImages(
         row.children[0],
-        this.#attachmentBaseUrl +
-          Utils.getIcon(this.#iconConfig, record.identifier),
-        16
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, record.identifier, "mac")
       );
-      row.children[1].textContent = record.identifier;
-      row.children[2].textContent = record.base.name;
-      row.children[3].textContent = new URL(record.base.urls.search.base).host;
-      this.#insertApplications(row.children[4], record.variants);
-      this.#insertDeployments(row.children[5], record);
+      Utils.addOrUpdateImages(
+        row.children[1],
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, record.identifier, "Android")
+      );
+      Utils.addOrUpdateImages(
+        row.children[2],
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, record.identifier, "iOS")
+      );
+      row.children[3].textContent = record.identifier;
+      row.children[4].textContent = record.base.name;
+      row.children[5].textContent = new URL(record.base.urls.search.base).host;
+      this.#insertApplications(row.children[6], record.variants);
+      this.#insertDeployments(row.children[7], record);
 
       currentRowIndex++;
     }
@@ -167,7 +180,7 @@ export default class AllEnginesView extends HTMLElement {
       throw new Error("Invalid Config");
     }
     this.#config = parsedConfig;
-    this.#iconConfig = await Utils.filterIconConfig(parsedIconConfig);
+    this.#iconConfig = parsedIconConfig;
     this.#attachmentBaseUrl = attachmentBaseUrl;
   }
 

--- a/extension/content/allEnginesView.mjs
+++ b/extension/content/allEnginesView.mjs
@@ -65,8 +65,14 @@ export default class AllEnginesView extends HTMLElement {
       if (rows.length <= currentRowIndex) {
         row = body.insertRow();
 
-        // Icon
+        // Desktop Icon
         let imageCell = row.insertCell();
+        imageCell.className = "icon";
+        // Android Icon
+        imageCell = row.insertCell();
+        imageCell.className = "icon";
+        // iOS Icon
+        imageCell = row.insertCell();
         imageCell.className = "icon";
         // Identifier
         row.insertCell();
@@ -83,17 +89,29 @@ export default class AllEnginesView extends HTMLElement {
         row = rows[currentRowIndex];
       }
 
-      Utils.addOrUpdateImage(
+      Utils.addOrUpdateImages(
         row.children[0],
-        this.#attachmentBaseUrl +
-          Utils.getIcon(this.#iconConfig, record.identifier),
-        16
+        this.#attachmentBaseUrl,
+        // On desktop it doesn't matter which platform we pick, since we don't
+        // have per-platform icons in search-config-icons. All the filtering
+        // checks are made against `Android` or `iOS`.
+        await Utils.getIcons(this.#iconConfig, record.identifier, "mac")
       );
-      row.children[1].textContent = record.identifier;
-      row.children[2].textContent = record.base.name;
-      row.children[3].textContent = new URL(record.base.urls.search.base).host;
-      this.#insertApplications(row.children[4], record.variants);
-      this.#insertDeployments(row.children[5], record);
+      Utils.addOrUpdateImages(
+        row.children[1],
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, record.identifier, "Android")
+      );
+      Utils.addOrUpdateImages(
+        row.children[2],
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, record.identifier, "iOS")
+      );
+      row.children[3].textContent = record.identifier;
+      row.children[4].textContent = record.base.name;
+      row.children[5].textContent = new URL(record.base.urls.search.base).host;
+      this.#insertApplications(row.children[6], record.variants);
+      this.#insertDeployments(row.children[7], record);
 
       currentRowIndex++;
     }
@@ -167,7 +185,7 @@ export default class AllEnginesView extends HTMLElement {
       throw new Error("Invalid Config");
     }
     this.#config = parsedConfig;
-    this.#iconConfig = await Utils.filterIconConfig(parsedIconConfig);
+    this.#iconConfig = parsedIconConfig;
     this.#attachmentBaseUrl = attachmentBaseUrl;
   }
 

--- a/extension/content/enginesView.css
+++ b/extension/content/enginesView.css
@@ -19,7 +19,7 @@
 
 #engines-table {
   display: grid;
-  grid-template-columns: repeat(8, max-content);
+  grid-template-columns: repeat(10, max-content);
   padding-top: 1em;
   margin: 0 auto;
   width: max-content;
@@ -29,19 +29,19 @@
   padding: 0.3em 1em;
 }
 
-#engines-table > div:nth-child(-n + 8) {
+#engines-table > div:nth-child(-n + 10) {
   font-weight: bold;
   text-align: center;
   padding-bottom: 0.5em;
 }
 
-#engines-table > div:nth-child(n + 8) {
+#engines-table > div:nth-child(n + 10) {
   opacity: 0.8;
   cursor: pointer;
 }
 
-#engines-table > div:nth-child(8n + 15),
-#engines-table > div:nth-child(8n + 16) {
+#engines-table > div:nth-child(10n + 15),
+#engines-table > div:nth-child(10n + 16) {
   opacity: 1;
   text-align: center;
 }
@@ -50,12 +50,12 @@
   opacity: 1;
 }
 
-#engines-table > div > img[size="16"] {
+#engines-table > div > a > img[size="16"] {
   width: 16px;
   height: 16px;
 }
 
-#engines-table > div > img[size="24"] {
+#engines-table > div > a > img[size="24"] {
   width: 24px;
   height: 24px;
 }

--- a/extension/content/enginesView.mjs
+++ b/extension/content/enginesView.mjs
@@ -108,7 +108,7 @@ export default class EnginesView extends HTMLElement {
       }
       this.#config = config;
       this.#configOverrides = configOverrides;
-      this.#iconConfig = await Utils.filterIconConfig(JSON.parse(iconConfig));
+      this.#iconConfig = JSON.parse(iconConfig);
 
       this.#attachmentBaseUrl = attachmentBaseUrl;
     }
@@ -139,7 +139,9 @@ export default class EnginesView extends HTMLElement {
     Utils.addDiv(fragment, "Partner Code");
     Utils.addDiv(fragment, "Classification");
     Utils.addDiv(fragment, "Aliases");
-    Utils.addDiv(fragment, "Desktop Icon");
+    Utils.addDiv(fragment, "Desktop");
+    Utils.addDiv(fragment, "Android");
+    Utils.addDiv(fragment, "iOS");
     for (let [i, e] of engines.entries()) {
       if (i == 0) {
         Utils.addDiv(fragment, "1 (Application Default)", e);
@@ -152,11 +154,22 @@ export default class EnginesView extends HTMLElement {
       Utils.addDiv(fragment, e.partnerCode, e);
       Utils.addDiv(fragment, e.classification, e);
       Utils.addDiv(fragment, e.aliases.join(", "), e);
-      Utils.addImage(
+      Utils.addImages(
         fragment,
-        this.#attachmentBaseUrl +
-          Utils.getIcon(this.#iconConfig, e.identifier, 16),
-        16,
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, e.identifier, "mac"),
+        e
+      );
+      Utils.addImages(
+        fragment,
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, e.identifier, "Android"),
+        e
+      );
+      Utils.addImages(
+        fragment,
+        this.#attachmentBaseUrl,
+        await Utils.getIcons(this.#iconConfig, e.identifier, "iOS"),
         e
       );
     }

--- a/extension/content/index.html
+++ b/extension/content/index.html
@@ -198,7 +198,9 @@
         <thead>
           <tr>
             <!-- Icon column -->
-            <th>Icon</th>
+            <th>Desktop</th>
+            <th>Android</th>
+            <th>iOS</th>
             <th>Engine Identifier</th>
             <th>Display Name</th>
             <th>Search URL Domain</th>

--- a/extension/content/script.mjs
+++ b/extension/content/script.mjs
@@ -93,7 +93,7 @@ async function showConfig(e) {
   if (e.target.tagName.toLowerCase() != "div") {
     return;
   }
-  let id = e.target.data.identifier;
+  let id = e.target.getAttribute("identifier");
   if (!id) {
     return;
   }

--- a/extension/content/utils.mjs
+++ b/extension/content/utils.mjs
@@ -3,12 +3,6 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 class _Utils {
-  /**
-   * @type {string}
-   *   The current browser platform.
-   */
-  #platform = null;
-
   addDiv(element, content, data = "", className = "") {
     let div = document.createElement("div");
     div.textContent = content;
@@ -45,25 +39,63 @@ class _Utils {
   }
 
   /**
-   * Adds or updates the image in the element.
+   * Adds multiple images in the element, indicating sizes if necessary.
    *
-   * @param {Element} parentElement
-   * @param {string} imageUrl
-   * @param {number} imageSize
+   * @param {Node} documentNode
+   * @param {string} baseUrl
+   * @param {{size: number, location: string, mimetype: string}[]} imageDetails
    * @param {string} data
    *   Any data to add as a property onto the div.
    */
-  addOrUpdateImage(parentElement, imageUrl, imageSize, data = "") {
-    if (
-      parentElement.firstChild?.tagName == "DIV" &&
-      parentElement.firstChild.firstChild?.tagName == "IMG" &&
-      parentElement.firstChild.firstChild?.getAttribute("size") == imageSize
-    ) {
-      parentElement.firstChild.firstChild.src = imageUrl;
-      return;
+  addImages(documentNode, baseUrl, imageDetails, data = "") {
+    let div = document.createElement("div");
+    if (data) {
+      div.data = data;
     }
-    this.removeAllChildren(parentElement);
-    this.addImage(parentElement, imageUrl, imageSize, data);
+
+    // For now, we only display one image, as we only ever ship one size of
+    // image in search-config-icons.
+    if (imageDetails.length) {
+      let anchor = document.createElement("a");
+      anchor.href = baseUrl + imageDetails[0].location;
+      anchor.target = "_blank";
+
+      if (imageDetails[0].mimetype == "application/pdf") {
+        anchor.textContent = "(pdf)";
+      } else {
+        let image = document.createElement("img");
+        image.src = baseUrl + imageDetails[0].location;
+        image.setAttribute("size", "16");
+        anchor.appendChild(image);
+      }
+      div.appendChild(anchor);
+    }
+    documentNode.appendChild(div);
+  }
+
+  /**
+   * Adds or updates the image in the element.
+   *
+   * @param {Node} documentNode
+   * @param {string} baseUrl
+   * @param {{size: number, location: string, mimetype: string}[]} imageDetails
+   * @param {string} data
+   *   Any data to add as a property onto the div.
+   */
+  addOrUpdateImages(documentNode, baseUrl, imageDetails, data = "") {
+    // TODO: Revisit this at some stage and consider making it work, so that
+    // when changing views, we're more efficient.
+    // if (
+    //   documentNode.firstChild?.tagName == "DIV" &&
+    //   documentNode.firstChild.firstChild?.tagName == "IMG"
+    //   documentNode.firstChild.firstChild?.getAttribute("size") == imageSize
+    // ) {
+    //   documentNode.firstChild.firstChild.src =
+    //     baseUrl + imageDetails[0].location;
+    //   return;
+    // }
+    this.removeAllChildren(documentNode);
+    this.addImages(documentNode, baseUrl, imageDetails, data);
   }
 
   insertOptionList(field, list) {
@@ -89,6 +121,17 @@ class _Utils {
   }
 
   /**
+   * @type {Map<string, boolean>}
+   *   A cache that is keyed by a record's filter_expression and the platform
+   *   being searched for. The value is the result of calling jexlFilterMatches
+   *   on the API.
+   *
+   *   This avoids repeatedly crossing the cross process boundary for each filter
+   *   call, hence speeding up display of icons, especially on the allEnginesView.
+   */
+  #filterCache = new Map();
+
+  /**
    * Filters search-config-icons, keeping records without a filter expression or
    * with expressions that matches the current platform. Only supports filtering
    * by OS, as that is all we currently require for search-config-icons.
@@ -96,19 +139,31 @@ class _Utils {
    * @param {object[]} unfilteredConfig
    * @returns object[]
    */
-  async filterIconConfig(unfilteredConfig) {
-    if (!this.#platform) {
-      this.#platform = (await browser.runtime.getPlatformInfo()).os;
-    }
+  async filterIconConfig(unfilteredConfig, platform) {
     let result = [];
     for (let record of unfilteredConfig.data) {
+      if (!record.filter_expression) {
+        result.push(record);
+        continue;
+      }
+
       if (
-        !record.filter_expression ||
-        (await browser.experiments.searchengines.jexlFilterMatches(
-          record.filter_expression,
-          this.#platform
-        ))
+        this.#filterCache.has(record.filter_expression + platform) != undefined
       ) {
+        if (this.#filterCache.get(record.filter_expression + platform)) {
+          result.push(record);
+          continue;
+        }
+      }
+
+      let matches = await browser.experiments.searchengines.jexlFilterMatches(
+        record.filter_expression,
+        platform
+      );
+
+      this.#filterCache.set(record.filter_expression + platform, matches);
+
+      if (matches) {
         result.push(record);
       }
     }
@@ -116,22 +171,23 @@ class _Utils {
   }
 
   /**
-   * Finds an icon in the remote settings records, according to the required
-   * size and returns the location.
+   * Finds any matching icon records in the remote settings records.
    *
    * @param {object[]} iconConfig
-   *   The filtered array of icon records from search-config-icons.
+   *   The array of icon records from search-config-icons.
    * @param {string} engineIdentifier
    *   The engine identifier.
-   * @param {number} iconSize
-   *   The requested size of the icon.
-   * @returns {string}
-   *   The location of the icon on the remote settings server.
+   * @param {string} platform
+   *   The platform to get the icons for.
    */
-  getIcon(iconConfig, engineIdentifier, iconSize) {
-    for (let record of iconConfig ?? []) {
+  async getIcons(iconConfig, engineIdentifier, platform) {
+    let filteredConfig = await this.filterIconConfig(iconConfig, platform);
+
+    /** @type {{size: number, location: string, mimetype: string}[]} */
+    let icons = [];
+
+    for (let record of filteredConfig) {
       if (
-        (!iconSize || record.imageSize == iconSize) &&
         record.engineIdentifiers.some((i) => {
           if (i.endsWith("*")) {
             return engineIdentifier.startsWith(i.slice(0, -1));
@@ -139,10 +195,14 @@ class _Utils {
           return engineIdentifier == i;
         })
       ) {
-        return record.attachment.location;
+        icons.push({
+          size: record.imageSize,
+          location: record.attachment.location,
+          mimetype: record.attachment.mimetype,
+        });
       }
     }
-    return null;
+    return icons;
   }
 }
 

--- a/extension/content/utils.mjs
+++ b/extension/content/utils.mjs
@@ -3,13 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 class _Utils {
-  /**
-   * @type {string}
-   *   The current browser platform.
-   */
-  #platform = null;
-
-  addDiv(element, content, data = "", className = "") {
+  addDiv(element, content, data, className = "") {
     let div = document.createElement("div");
     div.textContent = content;
     if (data) {
@@ -27,10 +21,10 @@ class _Utils {
    * @param {Element} parentElement
    * @param {string} imageUrl
    * @param {number} imageSize
-   * @param {string} data
+   * @param {object} data
    *   Any data to add as a property onto the div.
    */
-  addImage(parentElement, imageUrl, imageSize, data = "") {
+  addImage(parentElement, imageUrl, imageSize, data) {
     let div = document.createElement("div");
     if (data) {
       div.data = data;
@@ -45,25 +39,63 @@ class _Utils {
   }
 
   /**
-   * Adds or updates the image in the element.
+   * Adds multiple images in the element, indicating sizes if necessary.
    *
-   * @param {Element} parentElement
-   * @param {string} imageUrl
-   * @param {number} imageSize
-   * @param {string} data
+   * @param {Node} documentNode
+   * @param {string} baseUrl
+   * @param {{size: number, location: string, mimetype: string}[]} imageDetails
+   * @param {object} data
    *   Any data to add as a property onto the div.
    */
-  addOrUpdateImage(parentElement, imageUrl, imageSize, data = "") {
-    if (
-      parentElement.firstChild?.tagName == "DIV" &&
-      parentElement.firstChild.firstChild?.tagName == "IMG" &&
-      parentElement.firstChild.firstChild?.getAttribute("size") == imageSize
-    ) {
-      parentElement.firstChild.firstChild.src = imageUrl;
-      return;
+  addImages(documentNode, baseUrl, imageDetails, data) {
+    let div = document.createElement("div");
+    if (data) {
+      div.data = data;
     }
-    this.removeAllChildren(parentElement);
-    this.addImage(parentElement, imageUrl, imageSize, data);
+
+    // For now, we only display one image, as we only ever ship one size of
+    // image in search-config-icons.
+    if (imageDetails.length) {
+      let anchor = document.createElement("a");
+      anchor.href = baseUrl + imageDetails[0].location;
+      anchor.target = "_blank";
+
+      if (imageDetails[0].mimetype == "application/pdf") {
+        anchor.textContent = "(pdf)";
+      } else {
+        let image = document.createElement("img");
+        image.src = baseUrl + imageDetails[0].location;
+        image.setAttribute("size", "16");
+        anchor.appendChild(image);
+      }
+      div.appendChild(anchor);
+    }
+    documentNode.appendChild(div);
+  }
+
+  /**
+   * Adds or updates the image in the element.
+   *
+   * @param {Node} documentNode
+   * @param {string} baseUrl
+   * @param {{size: number, location: string, mimetype: string}[]} imageDetails
+   * @param {object} data
+   *   Any data to add as a property onto the div.
+   */
+  addOrUpdateImages(documentNode, baseUrl, imageDetails, data) {
+    // TODO: Revisit this at some stage and consider making it work, so that
+    // when changing views, we're more efficient.
+    // if (
+    //   documentNode.firstChild?.tagName == "DIV" &&
+    //   documentNode.firstChild.firstChild?.tagName == "IMG"
+    //   documentNode.firstChild.firstChild?.getAttribute("size") == imageSize
+    // ) {
+    //   documentNode.firstChild.firstChild.src =
+    //     baseUrl + imageDetails[0].location;
+    //   return;
+    // }
+    this.removeAllChildren(documentNode);
+    this.addImages(documentNode, baseUrl, imageDetails, data);
   }
 
   insertOptionList(field, list) {
@@ -89,6 +121,17 @@ class _Utils {
   }
 
   /**
+   * @type {Map<string, boolean>}
+   *   A cache that is keyed by a record's filter_expression and the platform
+   *   being searched for. The value is the result of calling jexlFilterMatches
+   *   on the API.
+   *
+   *   This avoids repeatedly crossing the cross process boundary for each filter
+   *   call, hence speeding up display of icons, especially on the allEnginesView.
+   */
+  #filterCache = new Map();
+
+  /**
    * Filters search-config-icons, keeping records without a filter expression or
    * with expressions that matches the current platform. Only supports filtering
    * by OS, as that is all we currently require for search-config-icons.
@@ -96,19 +139,32 @@ class _Utils {
    * @param {object[]} unfilteredConfig
    * @returns object[]
    */
-  async filterIconConfig(unfilteredConfig) {
-    if (!this.#platform) {
-      this.#platform = (await browser.runtime.getPlatformInfo()).os;
-    }
+  async filterIconConfig(unfilteredConfig, platform) {
     let result = [];
     for (let record of unfilteredConfig.data) {
-      if (
-        !record.filter_expression ||
-        (await browser.experiments.searchengines.jexlFilterMatches(
-          record.filter_expression,
-          this.#platform
-        ))
-      ) {
+      if (!record.filter_expression) {
+        result.push(record);
+        continue;
+      }
+
+      let cachedMatches = this.#filterCache.get(
+        record.filter_expression + platform
+      );
+      if (cachedMatches != undefined) {
+        if (cachedMatches) {
+          result.push(record);
+        }
+        continue;
+      }
+
+      let matches = await browser.experiments.searchengines.jexlFilterMatches(
+        record.filter_expression,
+        platform
+      );
+
+      this.#filterCache.set(record.filter_expression + platform, matches);
+
+      if (matches) {
         result.push(record);
       }
     }
@@ -116,22 +172,23 @@ class _Utils {
   }
 
   /**
-   * Finds an icon in the remote settings records, according to the required
-   * size and returns the location.
+   * Finds any matching icon records in the remote settings records.
    *
    * @param {object[]} iconConfig
-   *   The filtered array of icon records from search-config-icons.
+   *   The array of icon records from search-config-icons.
    * @param {string} engineIdentifier
    *   The engine identifier.
-   * @param {number} iconSize
-   *   The requested size of the icon.
-   * @returns {string}
-   *   The location of the icon on the remote settings server.
+   * @param {string} platform
+   *   The platform to get the icons for.
    */
-  getIcon(iconConfig, engineIdentifier, iconSize) {
-    for (let record of iconConfig ?? []) {
+  async getIcons(iconConfig, engineIdentifier, platform) {
+    let filteredConfig = await this.filterIconConfig(iconConfig, platform);
+
+    /** @type {{size: number, location: string, mimetype: string}[]} */
+    let icons = [];
+
+    for (let record of filteredConfig) {
       if (
-        (!iconSize || record.imageSize == iconSize) &&
         record.engineIdentifiers.some((i) => {
           if (i.endsWith("*")) {
             return engineIdentifier.startsWith(i.slice(0, -1));
@@ -139,10 +196,14 @@ class _Utils {
           return engineIdentifier == i;
         })
       ) {
-        return record.attachment.location;
+        icons.push({
+          size: record.imageSize,
+          location: record.attachment.location,
+          mimetype: record.attachment.mimetype,
+        });
       }
     }
-    return null;
+    return icons;
   }
 }
 

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "searchengine-devtools",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "browser_specific_settings": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "searchengine-devtools",
-  "version": "3.7.0",
+  "version": "3.8.0",
   "description": "A tool to help test search engine configuration changes",
   "homepage_url": "https://github.com/mozilla/searchengine-devtools",
   "webExt": {


### PR DESCRIPTION
There is currently an issue with display of Ecosia's icons, because they aren't flagged as size 16 (intentional). This fixes that by always displaying the first image found - currently we only have one image per platform, so that shouldn't be an issue. I had started to allow multiple images per platform, but decided to skip the full implementation for now.

This also adds display of images from all platforms. All images are clickable so that you can easily get to the source image.

For iOS we add `(pdf)` as a link, as it is not easy to get pdfs to display in-line without all the pdf additional items like toolbars etc.